### PR TITLE
feat: [#1] 로그인 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,9 @@ dependencies {
     implementation "org.springframework.boot:spring-boot-starter-web"
     implementation "org.springdoc:springdoc-openapi-starter-webmvc-ui:2.1.0"
     implementation "org.springframework.boot:spring-boot-starter-log4j2"
-    compileOnly "org.projectlombok:lombok"
+    implementation 'org.projectlombok:lombok'
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
 
     developmentOnly "org.springframework.boot:spring-boot-devtools"
     annotationProcessor "org.projectlombok:lombok"
@@ -60,4 +62,8 @@ tasks.named('bootBuildImage') {
 
 tasks.named('test') {
     useJUnitPlatform()
+}
+
+tasks.withType(JavaCompile).configureEach {
+    options.compilerArgs << "-parameters"
 }

--- a/src/main/java/potenday/pilsa/login/controller/LoginController.java
+++ b/src/main/java/potenday/pilsa/login/controller/LoginController.java
@@ -1,0 +1,45 @@
+package potenday.pilsa.login.controller;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseCookie;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import potenday.pilsa.login.dto.request.LoginRequest;
+import potenday.pilsa.login.dto.response.AccessTokenResponse;
+import potenday.pilsa.login.dto.response.TokenPair;
+import potenday.pilsa.login.service.LoginService;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1")
+public class LoginController {
+    private final LoginService loginService;
+
+    @PostMapping("/login")
+    public ResponseEntity<AccessTokenResponse> login(
+            @RequestBody LoginRequest request) {
+        TokenPair tokenPair = loginService.login(request);
+
+        // 엑세스 토큰은 프론트로 보내고 리프레쉬 토큰은 쿠키에 저장한다.
+        AccessTokenResponse accessTokenRes = AccessTokenResponse.builder()
+                .accessToken(tokenPair.getAccessToken())
+                .build();
+
+        ResponseCookie refreshTokenCookie = ResponseCookie.from("refreshToken", tokenPair.getRefreshToken())
+                .maxAge(3600) // 쿠키 유효 시간 설정 (초 단위)
+                .httpOnly(true) // HttpOnly 속성 설정 (JavaScript에서 접근 불가)
+//                .secure(true) // HTTPS에서만 전송되도록 설정 (선택적) TODO : 개발환경에서는 X
+                .path("/") // 쿠키의 경로 설정 (루트 경로로 설정)
+                .build();
+
+        // body 에는 엑세스토큰을 보내고 쿠키에는 리프레쉬 토큰 저장
+        return ResponseEntity.ok()
+                .header("Set-Cookie", refreshTokenCookie.toString())
+                .body(accessTokenRes);
+    }
+}

--- a/src/main/java/potenday/pilsa/login/domain/KakaoAuthClient.java
+++ b/src/main/java/potenday/pilsa/login/domain/KakaoAuthClient.java
@@ -1,0 +1,18 @@
+package potenday.pilsa.login.domain;
+
+import feign.Headers;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import potenday.pilsa.login.dto.request.KakaoOauthAccessTokenRequest;
+import potenday.pilsa.login.dto.response.KakaoOauthAccessTokenResponse;
+
+@FeignClient(name = "kakaoAuthClient", url = "${oauth2.kakao.token-base-uri}")
+public interface KakaoAuthClient {
+    @PostMapping(value = "/oauth/token", consumes = MediaType.APPLICATION_FORM_URLENCODED_VALUE)
+    @Headers("Content-Type: application/x-www-form-urlencoded")
+    ResponseEntity<KakaoOauthAccessTokenResponse> getAccessToken(@RequestBody KakaoOauthAccessTokenRequest request);
+
+}

--- a/src/main/java/potenday/pilsa/login/domain/KakaoMemberInfoClient.java
+++ b/src/main/java/potenday/pilsa/login/domain/KakaoMemberInfoClient.java
@@ -1,0 +1,14 @@
+package potenday.pilsa.login.domain;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import potenday.pilsa.login.dto.response.KakaoGetUserInfoResponse;
+
+@FeignClient(name = "KakaoMemberInfoClient", url = "${oauth2.kakao.member-info-base-uri}")
+public interface KakaoMemberInfoClient {
+    @GetMapping(value = "/v2/user/me")
+    ResponseEntity<KakaoGetUserInfoResponse> getMemberInfo(
+            @RequestHeader("Authorization") String authorizationHeader);
+}

--- a/src/main/java/potenday/pilsa/login/domain/KakaoProvider.java
+++ b/src/main/java/potenday/pilsa/login/domain/KakaoProvider.java
@@ -1,0 +1,73 @@
+package potenday.pilsa.login.domain;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import potenday.pilsa.login.dto.request.KakaoOauthAccessTokenRequest;
+import potenday.pilsa.login.dto.request.LoginRequest;
+import potenday.pilsa.login.dto.response.KakaoGetUserInfoResponse;
+import potenday.pilsa.login.dto.response.KakaoOauthAccessTokenResponse;
+import potenday.pilsa.login.dto.response.MemberInfoResponse;
+import potenday.pilsa.member.domain.SocialType;
+
+@Component
+@RequiredArgsConstructor
+public class KakaoProvider {
+    private final KakaoAuthClient kakaoAuthClient;
+    private final KakaoMemberInfoClient kakaoMemberInfoClient;
+
+    @Value("${oauth2.kakao.client-id}")
+    private String CLIENT_ID;
+
+    @Value("${oauth2.kakao.redirect-uri}")
+    private String REDIRECT_URI;
+
+    @Value("${oauth2.kakao.redirect-uri-local}")
+    private String REDIRECT_URI_LOCAL;
+
+    @Value("${oauth2.kakao.grant-type}")
+    private String GRANT_TYPE;
+
+    @Value("${oauth2.kakao.client-secret}")
+    private String CLIENT_SECRET;
+
+    public String getAccessToken(LoginRequest loginRequest) {
+        KakaoOauthAccessTokenRequest kakaoOauthAccessTokenRequest =
+                KakaoOauthAccessTokenRequest.builder()
+                        .client_id(CLIENT_ID)
+                        .grant_type(GRANT_TYPE)
+                        .client_secret(CLIENT_SECRET)
+                        .redirect_uri(loginRequest.getIsLocal() ? REDIRECT_URI_LOCAL : REDIRECT_URI)
+                        .code(loginRequest.getAuthCode())
+                .build();
+
+        ResponseEntity<KakaoOauthAccessTokenResponse> response = kakaoAuthClient.getAccessToken(kakaoOauthAccessTokenRequest);
+
+        // TODO : 에러 핸들링 하기
+        if (!response.getStatusCode().is2xxSuccessful() || !response.hasBody()) {
+            throw new NullPointerException();
+        }
+
+        return response.getBody().getAccess_token();
+    }
+
+    public MemberInfoResponse getMemberInfo(String accessToken) {
+        ResponseEntity<KakaoGetUserInfoResponse> response = kakaoMemberInfoClient.getMemberInfo("Bearer " + accessToken);
+
+        // TODO : 에러 핸들링 하기
+        if (!response.getStatusCode().is2xxSuccessful() || !response.hasBody()) {
+            throw new NullPointerException();
+        }
+
+        KakaoGetUserInfoResponse memberInfo = response.getBody();
+
+        return MemberInfoResponse.builder()
+                .socialType(SocialType.KAKAO)
+                .memberKey(memberInfo.getId().toString())
+                .nickName(memberInfo.getKakao_account().getProfile().getNickname())
+                .imageUrl(memberInfo.getKakao_account().getProfile().getProfile_image_url())
+                .email(memberInfo.getKakao_account().getEmail())
+                .build();
+    }
+}

--- a/src/main/java/potenday/pilsa/login/domain/RefreshToken.java
+++ b/src/main/java/potenday/pilsa/login/domain/RefreshToken.java
@@ -1,0 +1,31 @@
+package potenday.pilsa.login.domain;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.TimeToLive;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@RedisHash(value = "refreshToken")
+public class RefreshToken {
+    @Id
+    private String refreshToken;
+
+    private Long memberId;
+
+    @TimeToLive
+    @Value("${jwt.refresh-expiration-time}")
+    private Long timeToLive;
+
+    @Builder
+    public RefreshToken(String refreshToken, Long memberId, Long timeToLive) {
+        this.refreshToken = refreshToken;
+        this.memberId = memberId;
+        this.timeToLive = timeToLive;
+    }
+}

--- a/src/main/java/potenday/pilsa/login/domain/TokenProvider.java
+++ b/src/main/java/potenday/pilsa/login/domain/TokenProvider.java
@@ -1,0 +1,70 @@
+package potenday.pilsa.login.domain;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import potenday.pilsa.login.domain.repository.RefreshTokenRepository;
+import potenday.pilsa.login.dto.response.TokenPair;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+import java.util.UUID;
+
+@Component
+public class TokenProvider {
+    private final SecretKey secretKey;
+    private final Long accessTokenExpirationTime;
+    private final Long refreshTokenExpirationTime;
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    public TokenProvider(
+            @Value("${jwt.secret-key}") final String secretKey,
+            @Value("${jwt.access-expiration-time}") final Long accessTokenExpirationTime,
+            @Value("${jwt.refresh-expiration-time}") final Long refreshTokenExpirationTime,
+            RefreshTokenRepository refreshTokenRepository) {
+        this.secretKey = Keys.hmacShaKeyFor(secretKey.getBytes(StandardCharsets.UTF_8));
+        this.accessTokenExpirationTime = accessTokenExpirationTime;
+        this.refreshTokenExpirationTime = refreshTokenExpirationTime;
+        this.refreshTokenRepository = refreshTokenRepository;
+    }
+
+    public TokenPair createTokenPair(final Long memberId) {
+        String accessToken = createAccessToken(memberId);
+        String refreshToken = createRefreshToken();
+
+        saveRefreshToken(memberId, refreshToken);
+
+        return TokenPair.builder()
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .refreshTokenExpirationTime(refreshTokenExpirationTime)
+                .build();
+    }
+
+    private String createAccessToken(final Long memberId) {
+        final Date now = new Date();
+        final Date expirationDate = new Date(now.getTime() + accessTokenExpirationTime);
+
+        return Jwts.builder()
+                .subject(memberId.toString())
+                .issuedAt(now)
+                .expiration(expirationDate)
+                .signWith(secretKey)
+                .compact();
+    }
+
+    private String createRefreshToken() {
+        return UUID.randomUUID().toString();
+    }
+
+    private void saveRefreshToken(final Long memberId, String refreshToken) {
+        refreshTokenRepository.save(
+                RefreshToken.builder()
+                        .refreshToken(refreshToken)
+                        .memberId(memberId)
+                        .build()
+        );
+    }
+}

--- a/src/main/java/potenday/pilsa/login/domain/repository/RefreshTokenRepository.java
+++ b/src/main/java/potenday/pilsa/login/domain/repository/RefreshTokenRepository.java
@@ -1,0 +1,7 @@
+package potenday.pilsa.login.domain.repository;
+
+import org.springframework.data.repository.CrudRepository;
+import potenday.pilsa.login.domain.RefreshToken;
+
+public interface RefreshTokenRepository extends CrudRepository<RefreshToken, String> {
+}

--- a/src/main/java/potenday/pilsa/login/dto/request/KakaoOauthAccessTokenRequest.java
+++ b/src/main/java/potenday/pilsa/login/dto/request/KakaoOauthAccessTokenRequest.java
@@ -1,0 +1,26 @@
+package potenday.pilsa.login.dto.request;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+
+public class KakaoOauthAccessTokenRequest {
+    private String grant_type;
+    private String client_id;
+    private String redirect_uri;
+    private String code;
+    private String client_secret;
+
+    @Builder
+    public KakaoOauthAccessTokenRequest(String grant_type, String client_id, String redirect_uri, String code, String client_secret) {
+        this.grant_type = grant_type;
+        this.client_id = client_id;
+        this.redirect_uri = redirect_uri;
+        this.code = code;
+        this.client_secret = client_secret;
+    }
+}

--- a/src/main/java/potenday/pilsa/login/dto/request/LoginRequest.java
+++ b/src/main/java/potenday/pilsa/login/dto/request/LoginRequest.java
@@ -1,0 +1,14 @@
+package potenday.pilsa.login.dto.request;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import potenday.pilsa.member.domain.SocialType;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class LoginRequest {
+    private SocialType socialType;
+    private String authCode;
+    private Boolean isLocal;
+}

--- a/src/main/java/potenday/pilsa/login/dto/response/AccessTokenResponse.java
+++ b/src/main/java/potenday/pilsa/login/dto/response/AccessTokenResponse.java
@@ -1,0 +1,17 @@
+package potenday.pilsa.login.dto.response;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class AccessTokenResponse {
+    private String accessToken;
+
+    @Builder
+    public AccessTokenResponse(String accessToken) {
+        this.accessToken = accessToken;
+    }
+}

--- a/src/main/java/potenday/pilsa/login/dto/response/KakaoGetUserInfoResponse.java
+++ b/src/main/java/potenday/pilsa/login/dto/response/KakaoGetUserInfoResponse.java
@@ -1,0 +1,29 @@
+package potenday.pilsa.login.dto.response;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@ToString
+public class KakaoGetUserInfoResponse {
+    private Long id;
+    private KakaoAccount kakao_account;
+
+    @Getter
+    @Setter
+    @ToString
+    public static class KakaoAccount {
+        private Profile profile;
+        private String email;
+    }
+
+    @Getter
+    @Setter
+    @ToString
+    public static class Profile {
+        private String nickname;
+        private String profile_image_url;
+    }
+}

--- a/src/main/java/potenday/pilsa/login/dto/response/KakaoOauthAccessTokenResponse.java
+++ b/src/main/java/potenday/pilsa/login/dto/response/KakaoOauthAccessTokenResponse.java
@@ -1,0 +1,25 @@
+package potenday.pilsa.login.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class KakaoOauthAccessTokenResponse {
+    @JsonProperty("token_type")
+    private String token_type;
+    @JsonProperty("access_token")
+    private String access_token;
+    @JsonProperty("id_token")
+    private String id_token;
+    @JsonProperty("expires_in")
+    private Integer expires_in;
+    @JsonProperty("refresh_token")
+    private String refresh_token;
+    @JsonProperty("refresh_token_expires_in")
+    private Integer refresh_token_expires_in;
+    @JsonProperty("scope")
+    private String scope;
+}

--- a/src/main/java/potenday/pilsa/login/dto/response/MemberInfoResponse.java
+++ b/src/main/java/potenday/pilsa/login/dto/response/MemberInfoResponse.java
@@ -1,0 +1,26 @@
+package potenday.pilsa.login.dto.response;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import potenday.pilsa.member.domain.SocialType;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MemberInfoResponse {
+    private SocialType socialType;
+    private String memberKey;
+    private String imageUrl;
+    private String nickName;
+    private String email;
+
+    @Builder
+    public MemberInfoResponse(SocialType socialType, String memberKey, String imageUrl, String nickName, String email) {
+        this.socialType = socialType;
+        this.memberKey = memberKey;
+        this.imageUrl = imageUrl;
+        this.nickName = nickName;
+        this.email = email;
+    }
+}

--- a/src/main/java/potenday/pilsa/login/dto/response/TokenPair.java
+++ b/src/main/java/potenday/pilsa/login/dto/response/TokenPair.java
@@ -1,0 +1,19 @@
+package potenday.pilsa.login.dto.response;
+
+import lombok.*;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@ToString
+public class TokenPair {
+    private String accessToken;
+    private String refreshToken;
+    private Long refreshTokenExpirationTime;
+
+    @Builder
+    public TokenPair(String accessToken, String refreshToken, Long refreshTokenExpirationTime) {
+        this.accessToken = accessToken;
+        this.refreshToken = refreshToken;
+        this.refreshTokenExpirationTime = refreshTokenExpirationTime;
+    }
+}

--- a/src/main/java/potenday/pilsa/login/service/LoginService.java
+++ b/src/main/java/potenday/pilsa/login/service/LoginService.java
@@ -1,0 +1,40 @@
+package potenday.pilsa.login.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import potenday.pilsa.login.domain.KakaoProvider;
+import potenday.pilsa.login.domain.TokenProvider;
+import potenday.pilsa.login.dto.request.LoginRequest;
+import potenday.pilsa.login.dto.response.MemberInfoResponse;
+import potenday.pilsa.login.dto.response.TokenPair;
+import potenday.pilsa.member.domain.Member;
+import potenday.pilsa.member.domain.repository.MemberRepository;
+
+@Service
+@RequiredArgsConstructor
+public class LoginService {
+    private final MemberRepository memberRepository;
+    private final TokenProvider tokenProvider;
+    private final KakaoProvider kakaoProvider;
+
+    public TokenPair login(LoginRequest request) {
+        String accessToken = kakaoProvider.getAccessToken(request);
+        MemberInfoResponse memberInfo = kakaoProvider.getMemberInfo(accessToken);
+
+        Member member = memberRepository.findBySocialTypeAndMemberKey(request.getSocialType(), memberInfo.getMemberKey()).orElseGet(
+                () -> createMember(memberInfo)
+        );
+
+        return tokenProvider.createTokenPair(member.getId());
+    }
+
+    private Member createMember(MemberInfoResponse member) {
+        return memberRepository.save(
+                new Member(
+                        member.getSocialType(),
+                        member.getEmail(),
+                        member.getMemberKey(),
+                        member.getImageUrl(),
+                        member.getNickName()));
+    }
+}

--- a/src/main/java/potenday/pilsa/member/domain/Member.java
+++ b/src/main/java/potenday/pilsa/member/domain/Member.java
@@ -38,4 +38,14 @@ public class Member {
     private LocalDateTime registDate;
 
     private LocalDateTime updateDate;
+
+    public Member (SocialType socialType, String email, String memberKey, String profileImageUrl, String profileNickName) {
+        this.socialType = socialType;
+        this.email = email;
+        this.memberKey = memberKey;
+        this.profileImageUrl = profileImageUrl;
+        this.profileNickName = profileNickName;
+        this.registDate = LocalDateTime.now();
+        this.status = Status.ACTIVE;
+    }
 }

--- a/src/main/java/potenday/pilsa/member/domain/Member.java
+++ b/src/main/java/potenday/pilsa/member/domain/Member.java
@@ -29,7 +29,7 @@ public class Member {
 
     private String memberKey;
 
-    private String descript;
+    private String description;
 
     private String profileImageUrl;
 

--- a/src/main/java/potenday/pilsa/member/domain/repository/MemberRepository.java
+++ b/src/main/java/potenday/pilsa/member/domain/repository/MemberRepository.java
@@ -2,6 +2,10 @@ package potenday.pilsa.member.domain.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import potenday.pilsa.member.domain.Member;
+import potenday.pilsa.member.domain.SocialType;
+
+import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
+    Optional<Member> findBySocialTypeAndMemberKey(SocialType socialType, String memberKey);
 }


### PR DESCRIPTION
## 🔥 관련 이슈
Issue: #1 

## ✨ 변경사항
- 카카오와의 통신으로 엑세스토큰과 카카오 회원 정보를 가져옵니다.
- 신규회원이라면 Member 테이블에 저장하고 신규회원이 아니라면 로그인 로직으로 갑니다.
- 엑세스토큰과 리프레쉬 토큰을 발급 받습니다. 엑세스 토큰은 1시간의 유효기간을 가지고 리프레쉬 토큰은 2주의 유효기간을 가집니다.
- 리프레쉬 토큰은 Redis 에 저장됩니다.

## 📝 작업 유형
- [x] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 업데이트
- [ ] 단순 코드 스타일 변경 (세미콜론 추가 등)
- [ ] 배포 관련

## ✅ 체크리스트
- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] 해당 PR과 관련없는 변경사항이 없는가? (만약 있다면 제목이나 변경사항에 기술하여 주세요.)
- [x] 실행시 console 창에 에러나 경고가 없는것을 확인하였는가?