### PR TITLE
feat: [#8] 엑세스토큰과 리프레쉬 토큰을 활용해서 사용자 인증 구현

### DIFF
--- a/src/main/java/potenday/pilsa/global/config/AuthConfig.java
+++ b/src/main/java/potenday/pilsa/global/config/AuthConfig.java
@@ -1,0 +1,22 @@
+package potenday.pilsa.global.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import potenday.pilsa.login.AuthArgumentResolver;
+
+import java.util.List;
+
+// HTTP 요청이 들어오면 스프링에서 자동으로 파라미터를 해석하는데 우리는 토큰을 자체적으로 해석해야되므로
+// 커스텀 인자 리졸버를 등록하는 과정이 필요하다.
+@Configuration
+@RequiredArgsConstructor
+public class AuthConfig implements WebMvcConfigurer {
+    private final AuthArgumentResolver authArgumentResolver;
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(authArgumentResolver);
+    }
+}

--- a/src/main/java/potenday/pilsa/global/exception/AccessTokenException.java
+++ b/src/main/java/potenday/pilsa/global/exception/AccessTokenException.java
@@ -1,0 +1,10 @@
+package potenday.pilsa.global.exception;
+
+import lombok.Getter;
+
+@Getter
+public class AccessTokenException extends AuthException {
+    public AccessTokenException(final ExceptionCode exceptionCode) {
+        super(exceptionCode);
+    }
+}

--- a/src/main/java/potenday/pilsa/global/exception/AuthException.java
+++ b/src/main/java/potenday/pilsa/global/exception/AuthException.java
@@ -1,0 +1,10 @@
+package potenday.pilsa.global.exception;
+
+import lombok.Getter;
+
+@Getter
+public class AuthException extends BadRequestException {
+    public AuthException(final ExceptionCode exceptionCode) {
+        super(exceptionCode);
+    }
+}

--- a/src/main/java/potenday/pilsa/global/exception/BadRequestException.java
+++ b/src/main/java/potenday/pilsa/global/exception/BadRequestException.java
@@ -1,0 +1,14 @@
+package potenday.pilsa.global.exception;
+
+import lombok.Getter;
+
+@Getter
+public class BadRequestException extends RuntimeException{
+    private final int code;
+    private final String message;
+
+    public BadRequestException(final ExceptionCode exceptionCode) {
+        this.code = exceptionCode.getCode();
+        this.message = exceptionCode.getMessage();
+    }
+}

--- a/src/main/java/potenday/pilsa/global/exception/ExceptionCode.java
+++ b/src/main/java/potenday/pilsa/global/exception/ExceptionCode.java
@@ -1,0 +1,19 @@
+package potenday.pilsa.global.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ExceptionCode {
+    INVALID_REQUEST(1000, "올바르지 않은 요청입니다."),
+    EXPIRED_ACCESS_TOKEN(5101, "만료된 액세스 토큰입니다."),
+    EXPIRED_REFRESH_TOKEN(5102, "만료된 리프레시 토큰입니다."),
+    INVALID_ACCESS_TOKEN(5103, "유효하지 않은 액세스 토큰입니다."),
+    INVALID_REFRESH_TOKEN(5104, "유효하지 않은 리프레시 토큰입니다."),
+    FAIL_TO_VALIDATE_TOKEN(5105, "토큰 유효성 검사에 실패했습니다."),
+    INTERNAL_SEVER_ERROR(9999, "서버 에러가 발생하였습니다. 관리자에게 문의해 주세요.");
+
+    private final int code;
+    private final String message;
+}

--- a/src/main/java/potenday/pilsa/login/AccessTokenExtractor.java
+++ b/src/main/java/potenday/pilsa/login/AccessTokenExtractor.java
@@ -1,0 +1,16 @@
+package potenday.pilsa.login;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class AccessTokenExtractor {
+    private final String BEARER_TYPE = "Bearer";
+
+    public String extractAccessToken(String authorizationHeader) {
+        if(authorizationHeader==null || !authorizationHeader.startsWith(BEARER_TYPE)) {
+            throw new NullPointerException();
+        }
+
+        return authorizationHeader.substring(BEARER_TYPE.length()).trim();
+    }
+}

--- a/src/main/java/potenday/pilsa/login/Auth.java
+++ b/src/main/java/potenday/pilsa/login/Auth.java
@@ -1,0 +1,12 @@
+package potenday.pilsa.login;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Auth {
+    boolean required() default true;
+}

--- a/src/main/java/potenday/pilsa/login/AuthArgumentResolver.java
+++ b/src/main/java/potenday/pilsa/login/AuthArgumentResolver.java
@@ -1,0 +1,41 @@
+package potenday.pilsa.login;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+import potenday.pilsa.login.domain.TokenProvider;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class AuthArgumentResolver implements HandlerMethodArgumentResolver {
+    private final AccessTokenExtractor accessTokenExtractor;
+    private final TokenProvider tokenProvider;
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(Auth.class);
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+        Auth parameterAnnotation = parameter.getParameterAnnotation(Auth.class);
+
+        HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
+        String authorizationHeader = request.getHeader("Authorization");
+
+        if (!parameterAnnotation.required() && authorizationHeader.isBlank()){
+            return null;
+        }
+
+        String accessToken = accessTokenExtractor.extractAccessToken(authorizationHeader);
+
+        return tokenProvider.getMemberIdFromAccessToken(accessToken);
+    }
+}

--- a/src/main/java/potenday/pilsa/login/controller/LoginController.java
+++ b/src/main/java/potenday/pilsa/login/controller/LoginController.java
@@ -2,12 +2,10 @@ package potenday.pilsa.login.controller;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import potenday.pilsa.login.dto.request.LoginRequest;
 import potenday.pilsa.login.dto.response.AccessTokenResponse;
 import potenday.pilsa.login.dto.response.TokenPair;
@@ -41,5 +39,14 @@ public class LoginController {
         return ResponseEntity.ok()
                 .header("Set-Cookie", refreshTokenCookie.toString())
                 .body(accessTokenRes);
+    }
+
+    @PostMapping("/token")
+    public ResponseEntity<?> extendLogin(
+            @RequestHeader("Authorization") final String authorizationHeader,
+            @CookieValue("refresh-token") final String refreshToken) {
+
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(loginService.renewAccessToken(authorizationHeader, refreshToken));
     }
 }

--- a/src/main/java/potenday/pilsa/login/controller/LoginController.java
+++ b/src/main/java/potenday/pilsa/login/controller/LoginController.java
@@ -28,7 +28,7 @@ public class LoginController {
                 .accessToken(tokenPair.getAccessToken())
                 .build();
 
-        ResponseCookie refreshTokenCookie = ResponseCookie.from("refreshToken", tokenPair.getRefreshToken())
+        ResponseCookie refreshTokenCookie = ResponseCookie.from("refresh-token", tokenPair.getRefreshToken())
                 .maxAge(3600) // 쿠키 유효 시간 설정 (초 단위)
                 .httpOnly(true) // HttpOnly 속성 설정 (JavaScript에서 접근 불가)
 //                .secure(true) // HTTPS에서만 전송되도록 설정 (선택적) TODO : 개발환경에서는 X
@@ -45,7 +45,6 @@ public class LoginController {
     public ResponseEntity<?> extendLogin(
             @RequestHeader("Authorization") final String authorizationHeader,
             @CookieValue("refresh-token") final String refreshToken) {
-
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(loginService.renewAccessToken(authorizationHeader, refreshToken));
     }

--- a/src/main/java/potenday/pilsa/login/controller/LoginController.java
+++ b/src/main/java/potenday/pilsa/login/controller/LoginController.java
@@ -6,6 +6,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import potenday.pilsa.login.Auth;
 import potenday.pilsa.login.dto.request.LoginRequest;
 import potenday.pilsa.login.dto.response.AccessTokenResponse;
 import potenday.pilsa.login.dto.response.TokenPair;
@@ -44,8 +45,19 @@ public class LoginController {
     @PostMapping("/token")
     public ResponseEntity<?> extendLogin(
             @RequestHeader("Authorization") final String authorizationHeader,
-            @CookieValue("refresh-token") final String refreshToken) {
+            @CookieValue("refresh-token") final String refreshToken
+    ) {
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(loginService.renewAccessToken(authorizationHeader, refreshToken));
+    }
+
+    @DeleteMapping("/logout")
+    public ResponseEntity<Void> logout(
+            @Auth Long memberId,
+            @CookieValue("refresh-token") final String refreshToken
+            ) {
+        loginService.logout(refreshToken);
+
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/potenday/pilsa/login/domain/TokenProvider.java
+++ b/src/main/java/potenday/pilsa/login/domain/TokenProvider.java
@@ -8,6 +8,7 @@ import io.jsonwebtoken.security.Keys;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import potenday.pilsa.global.exception.AccessTokenException;
+import potenday.pilsa.global.exception.AuthException;
 import potenday.pilsa.global.exception.BadRequestException;
 import potenday.pilsa.global.exception.ExceptionCode;
 import potenday.pilsa.login.domain.repository.RefreshTokenRepository;
@@ -104,16 +105,12 @@ public class TokenProvider {
         return Long.parseLong(parseJwt(accessToken).getSubject());
     }
 
-    public Long getMemberIdFromExpiredJwtToken(String accessToken) {
-        try {
-            return Long.parseLong(Jwts.parser()
-                    .verifyWith(secretKey)
-                    .build()
-                    .parseSignedClaims(accessToken)
-                    .getPayload().getSubject());
-        } catch (ExpiredJwtException e) {
-            return Long.parseLong(e.getClaims().getSubject());
-        }
+    public Long getMemberIdFromExpiredJwtToken(String token) {
+        RefreshToken refreshToken = refreshTokenRepository.findById(token).orElseThrow(
+                () -> new AuthException(ExceptionCode.EXPIRED_REFRESH_TOKEN)
+        );
+
+        return refreshToken.getMemberId();
     }
 
     private Claims parseJwt(String token) {

--- a/src/main/java/potenday/pilsa/login/domain/TokenProvider.java
+++ b/src/main/java/potenday/pilsa/login/domain/TokenProvider.java
@@ -44,7 +44,7 @@ public class TokenProvider {
                 .build();
     }
 
-    private String createAccessToken(final Long memberId) {
+    public String createAccessToken(final Long memberId) {
         final Date now = new Date();
         final Date expirationDate = new Date(now.getTime() + accessTokenExpirationTime);
 
@@ -67,6 +67,30 @@ public class TokenProvider {
                         .memberId(memberId)
                         .build()
         );
+    }
+
+    public boolean isExpiredAccessAndValidRefreshToken(String accessToken, String refreshToken) {
+        try {
+            Long memberId = getMemberIdFromAccessToken(accessToken);
+            validateRefreshToken(refreshToken, memberId);
+            return false;
+        }  catch (Exception e) {
+            return false;
+        }
+    }
+
+    private void validateRefreshToken(String refreshToken, Long memberId) {
+        RefreshToken token = refreshTokenRepository.findById(refreshToken).orElseThrow(
+                NullPointerException::new
+        );
+
+        if (!memberId.equals(token.getMemberId())) {
+            throw new NullPointerException();
+        }
+    }
+
+    public void deleteRefreshToken(String refreshToken) {
+        refreshTokenRepository.deleteById(refreshToken);
     }
 
     public Long getMemberIdFromAccessToken(String accessToken) {

--- a/src/main/java/potenday/pilsa/login/domain/TokenProvider.java
+++ b/src/main/java/potenday/pilsa/login/domain/TokenProvider.java
@@ -1,5 +1,6 @@
 package potenday.pilsa.login.domain;
 
+import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
 import org.springframework.beans.factory.annotation.Value;
@@ -66,5 +67,17 @@ public class TokenProvider {
                         .memberId(memberId)
                         .build()
         );
+    }
+
+    public Long getMemberIdFromAccessToken(String accessToken) {
+        return Long.parseLong(parseJwt(accessToken).getSubject());
+    }
+
+    private Claims parseJwt(String token) {
+        return Jwts.parser()
+                .verifyWith(secretKey)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
     }
 }

--- a/src/main/java/potenday/pilsa/login/service/LoginService.java
+++ b/src/main/java/potenday/pilsa/login/service/LoginService.java
@@ -42,7 +42,7 @@ public class LoginService {
             throw new AuthException(ExceptionCode.FAIL_TO_VALIDATE_TOKEN);
         }
 
-        Long memberId = tokenProvider.getMemberIdFromExpiredJwtToken(accessToken);
+        Long memberId = tokenProvider.getMemberIdFromExpiredJwtToken(refreshToken);
 
         return AccessTokenResponse.builder()
                 .accessToken(tokenProvider.createAccessToken(memberId))

--- a/src/main/java/potenday/pilsa/login/service/LoginService.java
+++ b/src/main/java/potenday/pilsa/login/service/LoginService.java
@@ -2,6 +2,8 @@ package potenday.pilsa.login.service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import potenday.pilsa.global.exception.AuthException;
+import potenday.pilsa.global.exception.ExceptionCode;
 import potenday.pilsa.login.AccessTokenExtractor;
 import potenday.pilsa.login.domain.KakaoProvider;
 import potenday.pilsa.login.domain.TokenProvider;
@@ -32,15 +34,15 @@ public class LoginService {
     }
 
     public AccessTokenResponse renewAccessToken(
-            String authorizationHeader, String refreshToken) {
+            String authorizationHeader, String refreshToken)  {
         String accessToken = accessTokenExtractor.extractAccessToken(authorizationHeader);
 
         if (!tokenProvider.isExpiredAccessAndValidRefreshToken(accessToken, refreshToken)) {
             logout(refreshToken);
-            throw new NullPointerException();
+            throw new AuthException(ExceptionCode.FAIL_TO_VALIDATE_TOKEN);
         }
 
-        Long memberId = tokenProvider.getMemberIdFromAccessToken(accessToken);
+        Long memberId = tokenProvider.getMemberIdFromExpiredJwtToken(accessToken);
 
         return AccessTokenResponse.builder()
                 .accessToken(tokenProvider.createAccessToken(memberId))

--- a/src/main/java/potenday/pilsa/login/service/LoginService.java
+++ b/src/main/java/potenday/pilsa/login/service/LoginService.java
@@ -2,9 +2,11 @@ package potenday.pilsa.login.service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import potenday.pilsa.login.AccessTokenExtractor;
 import potenday.pilsa.login.domain.KakaoProvider;
 import potenday.pilsa.login.domain.TokenProvider;
 import potenday.pilsa.login.dto.request.LoginRequest;
+import potenday.pilsa.login.dto.response.AccessTokenResponse;
 import potenday.pilsa.login.dto.response.MemberInfoResponse;
 import potenday.pilsa.login.dto.response.TokenPair;
 import potenday.pilsa.member.domain.Member;
@@ -16,6 +18,7 @@ public class LoginService {
     private final MemberRepository memberRepository;
     private final TokenProvider tokenProvider;
     private final KakaoProvider kakaoProvider;
+    private final AccessTokenExtractor accessTokenExtractor;
 
     public TokenPair login(LoginRequest request) {
         String accessToken = kakaoProvider.getAccessToken(request);
@@ -26,6 +29,26 @@ public class LoginService {
         );
 
         return tokenProvider.createTokenPair(member.getId());
+    }
+
+    public AccessTokenResponse renewAccessToken(
+            String authorizationHeader, String refreshToken) {
+        String accessToken = accessTokenExtractor.extractAccessToken(authorizationHeader);
+
+        if (!tokenProvider.isExpiredAccessAndValidRefreshToken(accessToken, refreshToken)) {
+            logout(refreshToken);
+            throw new NullPointerException();
+        }
+
+        Long memberId = tokenProvider.getMemberIdFromAccessToken(accessToken);
+
+        return AccessTokenResponse.builder()
+                .accessToken(tokenProvider.createAccessToken(memberId))
+                .build();
+    }
+
+    public void logout(String refreshToken) {
+        tokenProvider.deleteRefreshToken(refreshToken);
     }
 
     private Member createMember(MemberInfoResponse member) {

--- a/src/main/java/potenday/pilsa/member/controller/MemberController.java
+++ b/src/main/java/potenday/pilsa/member/controller/MemberController.java
@@ -4,12 +4,10 @@ package potenday.pilsa.member.controller;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import potenday.pilsa.login.Auth;
 import potenday.pilsa.login.domain.TokenProvider;
+import potenday.pilsa.login.dto.response.TokenPair;
 
 @Slf4j
 @RestController
@@ -26,6 +24,16 @@ public class MemberController {
 
         System.out.println("memberId1 = " + mode);
         System.out.println("memberId2 = " + memberId);
+
+        return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/test")
+    public ResponseEntity<?> createToken() {
+        TokenPair tokenPair = tokenProvider.createTokenPair(1L);
+
+        System.out.println("tokenPair.getAccessToken() = " + tokenPair.getAccessToken());
+        System.out.println("tokenPair = " + tokenPair.getRefreshToken());
 
         return ResponseEntity.ok().build();
     }

--- a/src/main/java/potenday/pilsa/member/controller/MemberController.java
+++ b/src/main/java/potenday/pilsa/member/controller/MemberController.java
@@ -4,10 +4,13 @@ package potenday.pilsa.member.controller;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 import potenday.pilsa.login.Auth;
 import potenday.pilsa.login.domain.TokenProvider;
-import potenday.pilsa.login.dto.response.TokenPair;
+import potenday.pilsa.login.domain.repository.RefreshTokenRepository;
 
 @Slf4j
 @RestController
@@ -16,6 +19,7 @@ import potenday.pilsa.login.dto.response.TokenPair;
 public class MemberController {
 
     private final TokenProvider tokenProvider;
+    private final RefreshTokenRepository refreshTokenRepository;
 
     @GetMapping("/member")
     public ResponseEntity<?> getMemberInfo(
@@ -24,16 +28,6 @@ public class MemberController {
 
         System.out.println("memberId1 = " + mode);
         System.out.println("memberId2 = " + memberId);
-
-        return ResponseEntity.ok().build();
-    }
-
-    @GetMapping("/test")
-    public ResponseEntity<?> createToken() {
-        TokenPair tokenPair = tokenProvider.createTokenPair(1L);
-
-        System.out.println("tokenPair.getAccessToken() = " + tokenPair.getAccessToken());
-        System.out.println("tokenPair = " + tokenPair.getRefreshToken());
 
         return ResponseEntity.ok().build();
     }

--- a/src/main/java/potenday/pilsa/member/controller/MemberController.java
+++ b/src/main/java/potenday/pilsa/member/controller/MemberController.java
@@ -1,0 +1,33 @@
+package potenday.pilsa.member.controller;
+
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import potenday.pilsa.login.Auth;
+import potenday.pilsa.login.domain.TokenProvider;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1")
+public class MemberController {
+
+    private final TokenProvider tokenProvider;
+
+    @GetMapping("/member")
+    public ResponseEntity<?> getMemberInfo(
+            @Auth Long memberId,
+            @RequestParam(value = "mode", required = false) String mode) {
+
+        System.out.println("memberId1 = " + mode);
+        System.out.println("memberId2 = " + memberId);
+
+        return ResponseEntity.ok().build();
+    }
+
+}


### PR DESCRIPTION
## 🔥 관련 이슈
Issue: #8 

## ✨ 변경사항
- 엑세스 토큰이 만료되었다면 리프레쉬 토큰을 활용해서 엑세스 토큰을 재발급 해줘요
- 엑세스 토큰이 들어오면 엑세스 토큰의 유효성을 검사하고 회원의 Id 를 추출해줘요

## 📝 작업 유형
- [x] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 업데이트
- [ ] 단순 코드 스타일 변경 (세미콜론 추가 등)
- [ ] 배포 관련

## ✅ 체크리스트
- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] 해당 PR과 관련없는 변경사항이 없는가? (만약 있다면 제목이나 변경사항에 기술하여 주세요.)
- [x] 실행시 console 창에 에러나 경고가 없는것을 확인하였는가?
