### PR TITLE
feat: [#15] 회원 CRUD API 를 개발했어요.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,7 @@ dependencies {
     implementation 'org.projectlombok:lombok'
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
 
     developmentOnly "org.springframework.boot:spring-boot-devtools"
     annotationProcessor "org.projectlombok:lombok"

--- a/src/main/java/potenday/pilsa/global/config/CustomExceptionHandler.java
+++ b/src/main/java/potenday/pilsa/global/config/CustomExceptionHandler.java
@@ -1,0 +1,26 @@
+package potenday.pilsa.global.config;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.context.request.WebRequest;
+import potenday.pilsa.global.dto.response.CustomErrorResponse;
+
+
+@ControllerAdvice
+public class CustomExceptionHandler {
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<CustomErrorResponse> handleValidationExceptions(
+            MethodArgumentNotValidException ex, WebRequest request) {
+        String errorMessage = ex.getBindingResult().getAllErrors().isEmpty() ? "Validation failed. Please check the request."
+                : ex.getBindingResult().getAllErrors().get(0).getDefaultMessage();
+
+        CustomErrorResponse errorResponse = new CustomErrorResponse(HttpStatus.BAD_REQUEST.value(), errorMessage);
+
+        return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);
+    }
+
+}

--- a/src/main/java/potenday/pilsa/global/config/CustomResponseEntityExceptionHandler.java
+++ b/src/main/java/potenday/pilsa/global/config/CustomResponseEntityExceptionHandler.java
@@ -1,0 +1,29 @@
+package potenday.pilsa.global.config;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+import potenday.pilsa.global.exception.BadRequestException;
+
+@ControllerAdvice
+public class CustomResponseEntityExceptionHandler extends ResponseEntityExceptionHandler {
+    private static final Logger logger = LoggerFactory.getLogger(CustomResponseEntityExceptionHandler.class);
+
+
+    @ExceptionHandler(BadRequestException.class)
+    public final ResponseEntity<ErrorResponse> handleAuthException(BadRequestException ex, WebRequest request) {
+        ErrorResponse errorResponse = new ErrorResponse(ex.getCode(), ex.getMessage());
+
+        logger.error("ERROR: {}", ex.getMessage(), ex);
+
+        return new ResponseEntity<>(errorResponse, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+
+    private record ErrorResponse(int code, String message) {
+    }
+}

--- a/src/main/java/potenday/pilsa/global/config/CustomResponseExceptionHandler.java
+++ b/src/main/java/potenday/pilsa/global/config/CustomResponseExceptionHandler.java
@@ -11,9 +11,8 @@ import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExcep
 import potenday.pilsa.global.exception.BadRequestException;
 
 @ControllerAdvice
-public class CustomResponseEntityExceptionHandler extends ResponseEntityExceptionHandler {
-    private static final Logger logger = LoggerFactory.getLogger(CustomResponseEntityExceptionHandler.class);
-
+public class CustomResponseExceptionHandler extends ResponseEntityExceptionHandler {
+    private static final Logger logger = LoggerFactory.getLogger(CustomResponseExceptionHandler.class);
 
     @ExceptionHandler(BadRequestException.class)
     public final ResponseEntity<ErrorResponse> handleAuthException(BadRequestException ex, WebRequest request) {

--- a/src/main/java/potenday/pilsa/global/config/SwaggerConfig.java
+++ b/src/main/java/potenday/pilsa/global/config/SwaggerConfig.java
@@ -3,16 +3,30 @@ package potenday.pilsa.global.config;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+
+import java.util.Collections;
 
 @Configuration
 public class SwaggerConfig {
 
     @Bean
     public OpenAPI openAPI() {
+        SecurityScheme securityScheme = new SecurityScheme()
+                .type(SecurityScheme.Type.HTTP)
+                .scheme("bearer")
+                .bearerFormat("JWT")
+                .in(SecurityScheme.In.HEADER)
+                .name("Authorization");
+
+        SecurityRequirement securityRequirement = new SecurityRequirement().addList("bearerAuth");
+
         return new OpenAPI()
-                .components(new Components())
+                .components(new Components().addSecuritySchemes("bearerAuth", securityScheme))
+                .security(Collections.singletonList(securityRequirement))
                 .info(apiInfo());
     }
 

--- a/src/main/java/potenday/pilsa/global/dto/response/CustomErrorResponse.java
+++ b/src/main/java/potenday/pilsa/global/dto/response/CustomErrorResponse.java
@@ -1,0 +1,14 @@
+package potenday.pilsa.global.dto.response;
+
+import lombok.Getter;
+
+@Getter
+public class CustomErrorResponse {
+    private int status;
+    private String message;
+
+    public CustomErrorResponse(int status, String message) {
+        this.status = status;
+        this.message = message;
+    }
+}

--- a/src/main/java/potenday/pilsa/global/exception/ExceptionCode.java
+++ b/src/main/java/potenday/pilsa/global/exception/ExceptionCode.java
@@ -7,6 +7,9 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum ExceptionCode {
     INVALID_REQUEST(1000, "올바르지 않은 요청입니다."),
+
+    NOT_FOUND_MEMBER(2001, "회원을 찾을 수 없습니다."),
+
     EXPIRED_ACCESS_TOKEN(5101, "만료된 액세스 토큰입니다."),
     EXPIRED_REFRESH_TOKEN(5102, "만료된 리프레시 토큰입니다."),
     INVALID_ACCESS_TOKEN(5103, "유효하지 않은 액세스 토큰입니다."),

--- a/src/main/java/potenday/pilsa/login/AccessTokenExtractor.java
+++ b/src/main/java/potenday/pilsa/login/AccessTokenExtractor.java
@@ -1,6 +1,8 @@
 package potenday.pilsa.login;
 
 import org.springframework.stereotype.Component;
+import potenday.pilsa.global.exception.AuthException;
+import potenday.pilsa.global.exception.ExceptionCode;
 
 @Component
 public class AccessTokenExtractor {
@@ -8,7 +10,7 @@ public class AccessTokenExtractor {
 
     public String extractAccessToken(String authorizationHeader) {
         if(authorizationHeader==null || !authorizationHeader.startsWith(BEARER_TYPE)) {
-            throw new NullPointerException();
+            throw new AuthException(ExceptionCode.FAIL_TO_VALIDATE_TOKEN);
         }
 
         return authorizationHeader.substring(BEARER_TYPE.length()).trim();

--- a/src/main/java/potenday/pilsa/login/controller/LoginController.java
+++ b/src/main/java/potenday/pilsa/login/controller/LoginController.java
@@ -1,5 +1,9 @@
 package potenday.pilsa.login.controller;
 
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -12,6 +16,7 @@ import potenday.pilsa.login.dto.response.AccessTokenResponse;
 import potenday.pilsa.login.dto.response.TokenPair;
 import potenday.pilsa.login.service.LoginService;
 
+@Tag(name = "로그인 Controller")
 @Slf4j
 @RestController
 @RequiredArgsConstructor
@@ -19,6 +24,7 @@ import potenday.pilsa.login.service.LoginService;
 public class LoginController {
     private final LoginService loginService;
 
+    @Operation(summary = "회원가입 & 로그인", description = "")
     @PostMapping("/login")
     public ResponseEntity<AccessTokenResponse> login(
             @RequestBody LoginRequest request) {
@@ -42,8 +48,9 @@ public class LoginController {
                 .body(accessTokenRes);
     }
 
+    @Operation(summary = "엑세스 토큰이 만료되었을때 토큰 반환", description = "AccessTokenResponse")
     @PostMapping("/token")
-    public ResponseEntity<?> extendLogin(
+    public ResponseEntity<AccessTokenResponse> extendLogin(
             @RequestHeader("Authorization") final String authorizationHeader,
             @CookieValue("refresh-token") final String refreshToken
     ) {
@@ -51,9 +58,10 @@ public class LoginController {
                 .body(loginService.renewAccessToken(authorizationHeader, refreshToken));
     }
 
+    @Operation(summary = "로그아웃", description = "")
     @DeleteMapping("/logout")
     public ResponseEntity<Void> logout(
-            @Auth Long memberId,
+            @Parameter(hidden = true) @Auth Long memberId,
             @CookieValue("refresh-token") final String refreshToken
             ) {
         loginService.logout(refreshToken);

--- a/src/main/java/potenday/pilsa/login/dto/request/LoginRequest.java
+++ b/src/main/java/potenday/pilsa/login/dto/request/LoginRequest.java
@@ -1,5 +1,6 @@
 package potenday.pilsa.login.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -7,8 +8,12 @@ import potenday.pilsa.member.domain.SocialType;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Schema(description = "로그인 RequestDto")
 public class LoginRequest {
+    @Schema(description = "소셜 타입 [KAKAO : 카카오, GOOGLE : 구글, ETC : 그외]")
     private SocialType socialType;
+    @Schema(description = "소셜 로그인 시 받아오는 인가코드")
     private String authCode;
+    @Schema(description = "요청이 localhost:3030 일 경우 true / 그외 false")
     private Boolean isLocal;
 }

--- a/src/main/java/potenday/pilsa/login/dto/response/AccessTokenResponse.java
+++ b/src/main/java/potenday/pilsa/login/dto/response/AccessTokenResponse.java
@@ -1,5 +1,6 @@
 package potenday.pilsa.login.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -8,6 +9,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class AccessTokenResponse {
+    @Schema(name = "accessToken", description = "엑세스 토큰")
     private String accessToken;
 
     @Builder

--- a/src/main/java/potenday/pilsa/member/controller/MemberController.java
+++ b/src/main/java/potenday/pilsa/member/controller/MemberController.java
@@ -45,7 +45,17 @@ public class MemberController {
         return ResponseEntity.ok(memberService.updateMember(memberId, request));
     }
 
-    @Operation(summary = "회원 번호 1의 테스트 엑세스토큰을 생성합니다.", description = "")
+    @Operation(summary = "회원을 탈퇴 시키는 API", description = "")
+    @DeleteMapping("/member")
+    public ResponseEntity<Void> deleteMember(
+            @Parameter(hidden = true) @Auth Long memberId,
+            @CookieValue("refresh-token") final String refreshToken) {
+        memberService.deleteMember(memberId, refreshToken);
+
+        return ResponseEntity.noContent().build();
+    }
+
+    @Operation(summary = "[TEST API]회원 번호 1의 테스트 엑세스토큰을 생성합니다.", description = "토큰 테스트를 위한 API 입니다 되도록 리프레쉬 토큰까지 생성되는것 보다 해당 API 를 활용해주세요. 리프레쉬 토큰은 저장되기 때문이에요.")
     @PostMapping("/test/get-access-token")
     public ResponseEntity<AccessTokenResponse> getToken() {
         String accessToken = tokenProvider.createAccessToken(1L);
@@ -56,7 +66,7 @@ public class MemberController {
                 .build());
     }
 
-    @Operation(summary = "회원 번호 1의 테스트 엑세스토큰&리프레쉬 토큰을 생성합니다.", description = "")
+    @Operation(summary = "[TEST API]회원 번호 1의 테스트 엑세스토큰&리프레쉬 토큰을 생성합니다.", description = " 리프레쉬 토큰은 저장되기 때문에 되도록 엑세스 토큰 발급만 하는 API 를 활용해주세요! 리프레쉬 토큰이 꼭 필요하다면 해당 API 로 발급해주세요!")
     @PostMapping("/test/get-all-token")
     public ResponseEntity<TokenPair> getAllToken() {
         TokenPair tokenPair = tokenProvider.createTokenPair(1L);

--- a/src/main/java/potenday/pilsa/member/controller/MemberController.java
+++ b/src/main/java/potenday/pilsa/member/controller/MemberController.java
@@ -1,35 +1,68 @@
 package potenday.pilsa.member.controller;
 
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
 import potenday.pilsa.login.Auth;
 import potenday.pilsa.login.domain.TokenProvider;
-import potenday.pilsa.login.domain.repository.RefreshTokenRepository;
+import potenday.pilsa.login.dto.response.AccessTokenResponse;
+import potenday.pilsa.login.dto.response.TokenPair;
+import potenday.pilsa.member.dto.request.MemberUpdateRequest;
+import potenday.pilsa.member.dto.response.MemberInfoResponse;
+import potenday.pilsa.member.service.MemberService;
 
+@Tag(name = "회원 관련 API")
 @Slf4j
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1")
 public class MemberController {
 
+    private final MemberService memberService;
     private final TokenProvider tokenProvider;
-    private final RefreshTokenRepository refreshTokenRepository;
 
+    @Operation(summary = "토큰으로 회원 정보 가져오는 API", description = "")
     @GetMapping("/member")
-    public ResponseEntity<?> getMemberInfo(
-            @Auth Long memberId,
-            @RequestParam(value = "mode", required = false) String mode) {
+    public ResponseEntity<MemberInfoResponse> getMemberInfo(
+            @Parameter(hidden = true) @Auth Long memberId) {
 
-        System.out.println("memberId1 = " + mode);
-        System.out.println("memberId2 = " + memberId);
-
-        return ResponseEntity.ok().build();
+        return ResponseEntity.ok(memberService.getMemberInfo(memberId));
     }
+
+    @Operation(summary = "회원의 소개글을 변경하는 API", description = "")
+    @PutMapping("/member")
+    public ResponseEntity<MemberInfoResponse> modifyMemberInfo(
+            @Parameter(hidden = true) @Auth Long memberId,
+            @RequestBody @Valid MemberUpdateRequest request) {
+
+        return ResponseEntity.ok(memberService.updateMember(memberId, request));
+    }
+
+    @Operation(summary = "회원 번호 1의 테스트 엑세스토큰을 생성합니다.", description = "")
+    @PostMapping("/test/get-access-token")
+    public ResponseEntity<AccessTokenResponse> getToken() {
+        String accessToken = tokenProvider.createAccessToken(1L);
+
+        return ResponseEntity.ok(
+                AccessTokenResponse.builder()
+                .accessToken(accessToken)
+                .build());
+    }
+
+    @Operation(summary = "회원 번호 1의 테스트 엑세스토큰&리프레쉬 토큰을 생성합니다.", description = "")
+    @PostMapping("/test/get-all-token")
+    public ResponseEntity<TokenPair> getAllToken() {
+        TokenPair tokenPair = tokenProvider.createTokenPair(1L);
+
+        return ResponseEntity.ok(tokenPair);
+    }
+
 
 }

--- a/src/main/java/potenday/pilsa/member/domain/Member.java
+++ b/src/main/java/potenday/pilsa/member/domain/Member.java
@@ -49,4 +49,8 @@ public class Member {
         this.registDate = LocalDateTime.now();
         this.status = Status.ACTIVE;
     }
+
+    public void updateDescription(String description) {
+        this.description = description;
+    }
 }

--- a/src/main/java/potenday/pilsa/member/domain/Member.java
+++ b/src/main/java/potenday/pilsa/member/domain/Member.java
@@ -12,6 +12,9 @@ import java.time.LocalDateTime;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "memberInfo")
 public class Member {
+    private static final String DELETED_MEMBER_NICKNAME = "탈퇴회원";
+    // TODO : 나중에 다른 디폴트 이미지로 변경
+    private static final String DEFAULT_IMAGE = "https://weavers-siltarae.s3.ap-northeast-2.amazonaws.com/profile/default_image.png";
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -52,5 +55,17 @@ public class Member {
 
     public void updateDescription(String description) {
         this.description = description;
+        this.updateDate = LocalDateTime.now();
     }
+
+    public void deleteMember() {
+        this.status = Status.RESIGN;
+        this.email = null;
+        this.memberKey = null;
+        this.description = null;
+        this.profileImageUrl = DEFAULT_IMAGE;
+        this.profileNickName = DELETED_MEMBER_NICKNAME;
+        this.registDate = LocalDateTime.now();
+    }
+
 }

--- a/src/main/java/potenday/pilsa/member/domain/repository/MemberRepository.java
+++ b/src/main/java/potenday/pilsa/member/domain/repository/MemberRepository.java
@@ -3,9 +3,11 @@ package potenday.pilsa.member.domain.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import potenday.pilsa.member.domain.Member;
 import potenday.pilsa.member.domain.SocialType;
+import potenday.pilsa.member.domain.Status;
 
 import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findBySocialTypeAndMemberKey(SocialType socialType, String memberKey);
+    Optional<Member> findByIdAndStatus(Long id, Status status);
 }

--- a/src/main/java/potenday/pilsa/member/dto/request/MemberUpdateRequest.java
+++ b/src/main/java/potenday/pilsa/member/dto/request/MemberUpdateRequest.java
@@ -10,7 +10,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class MemberUpdateRequest {
 
-    @Size(max = 50, message = "소개글은 최대 50자로 작성할 수 있습니다.")
+    @Size(max = 100, message = "소개글은 최대 100자로 작성할 수 있습니다.")
     private String description;
 
     @Builder

--- a/src/main/java/potenday/pilsa/member/dto/request/MemberUpdateRequest.java
+++ b/src/main/java/potenday/pilsa/member/dto/request/MemberUpdateRequest.java
@@ -1,0 +1,20 @@
+package potenday.pilsa.member.dto.request;
+
+import jakarta.validation.constraints.Size;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MemberUpdateRequest {
+
+    @Size(max = 50, message = "소개글은 최대 50자로 작성할 수 있습니다.")
+    private String description;
+
+    @Builder
+    public MemberUpdateRequest(String description) {
+        this.description = description;
+    }
+}

--- a/src/main/java/potenday/pilsa/member/dto/response/MemberInfoResponse.java
+++ b/src/main/java/potenday/pilsa/member/dto/response/MemberInfoResponse.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 import potenday.pilsa.member.domain.Member;
+import potenday.pilsa.member.domain.Status;
 
 @Getter
 public class MemberInfoResponse {
@@ -13,16 +14,18 @@ public class MemberInfoResponse {
     private String nickName;
     @Schema(description = "회원 이미지 URL")
     private String imageUrl;
-
     @Schema(description = "회원 소개글")
     private String description;
+    @Schema(description = "회원 상태 [ACTIVE : 활성, IDLE : 휴면, RESIGN : 탈퇴]")
+    private Status status;
 
     @Builder
-    public MemberInfoResponse(Long id, String nickName, String imageUrl, String description) {
+    public MemberInfoResponse(Long id, String nickName, String imageUrl, String description, Status status) {
         this.id = id;
         this.nickName = nickName;
         this.imageUrl = imageUrl;
         this.description = description;
+        this.status = status;
     }
 
     public static MemberInfoResponse from(Member member) {
@@ -31,6 +34,7 @@ public class MemberInfoResponse {
                 .nickName(member.getProfileNickName())
                 .imageUrl(member.getProfileImageUrl())
                 .description(member.getDescription())
+                .status(member.getStatus())
                 .build();
     }
 }

--- a/src/main/java/potenday/pilsa/member/dto/response/MemberInfoResponse.java
+++ b/src/main/java/potenday/pilsa/member/dto/response/MemberInfoResponse.java
@@ -1,0 +1,36 @@
+package potenday.pilsa.member.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+import potenday.pilsa.member.domain.Member;
+
+@Getter
+public class MemberInfoResponse {
+    @Schema(description = "회원 ID")
+    private Long id;
+    @Schema(description = "회원 닉네임")
+    private String nickName;
+    @Schema(description = "회원 이미지 URL")
+    private String imageUrl;
+
+    @Schema(description = "회원 소개글")
+    private String description;
+
+    @Builder
+    public MemberInfoResponse(Long id, String nickName, String imageUrl, String description) {
+        this.id = id;
+        this.nickName = nickName;
+        this.imageUrl = imageUrl;
+        this.description = description;
+    }
+
+    public static MemberInfoResponse from(Member member) {
+        return MemberInfoResponse.builder()
+                .id(member.getId())
+                .nickName(member.getProfileNickName())
+                .imageUrl(member.getProfileImageUrl())
+                .description(member.getDescription())
+                .build();
+    }
+}

--- a/src/main/java/potenday/pilsa/member/service/MemberService.java
+++ b/src/main/java/potenday/pilsa/member/service/MemberService.java
@@ -5,6 +5,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import potenday.pilsa.global.exception.BadRequestException;
 import potenday.pilsa.global.exception.ExceptionCode;
+import potenday.pilsa.login.domain.TokenProvider;
 import potenday.pilsa.member.domain.Member;
 import potenday.pilsa.member.domain.Status;
 import potenday.pilsa.member.domain.repository.MemberRepository;
@@ -15,6 +16,7 @@ import potenday.pilsa.member.dto.response.MemberInfoResponse;
 @RequiredArgsConstructor
 public class MemberService {
     private final MemberRepository memberRepository;
+    private final TokenProvider tokenProvider;
 
     public MemberInfoResponse getMemberInfo(Long memberId) {
         Member member = getMember(memberId);
@@ -28,6 +30,14 @@ public class MemberService {
         member.updateDescription(request.getDescription());
 
         return MemberInfoResponse.from(member);
+    }
+
+    @Transactional
+    public void deleteMember(Long memberId, String refreshToken) {
+        Member member = getMember(memberId);
+        member.deleteMember();
+
+        tokenProvider.deleteRefreshToken(refreshToken);
     }
 
     private Member getMember(Long memberId) {

--- a/src/main/java/potenday/pilsa/member/service/MemberService.java
+++ b/src/main/java/potenday/pilsa/member/service/MemberService.java
@@ -1,0 +1,38 @@
+package potenday.pilsa.member.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import potenday.pilsa.global.exception.BadRequestException;
+import potenday.pilsa.global.exception.ExceptionCode;
+import potenday.pilsa.member.domain.Member;
+import potenday.pilsa.member.domain.Status;
+import potenday.pilsa.member.domain.repository.MemberRepository;
+import potenday.pilsa.member.dto.request.MemberUpdateRequest;
+import potenday.pilsa.member.dto.response.MemberInfoResponse;
+
+@Service
+@RequiredArgsConstructor
+public class MemberService {
+    private final MemberRepository memberRepository;
+
+    public MemberInfoResponse getMemberInfo(Long memberId) {
+        Member member = getMember(memberId);
+
+        return MemberInfoResponse.from(member);
+    }
+
+    @Transactional
+    public MemberInfoResponse updateMember(Long memberId, MemberUpdateRequest request) {
+        Member member = getMember(memberId);
+        member.updateDescription(request.getDescription());
+
+        return MemberInfoResponse.from(member);
+    }
+
+    private Member getMember(Long memberId) {
+        return memberRepository.findByIdAndStatus(memberId, Status.ACTIVE).orElseThrow(
+                () -> new BadRequestException(ExceptionCode.NOT_FOUND_MEMBER)
+        );
+    }
+}


### PR DESCRIPTION
## 🔥 관련 이슈
Issue: #15 

## ✨ 변경사항
- 회원의 소개글을 변경하는 API 를 개발했어요 소개글은 공백포함 100자 이내로 입력할 수 있어요.
- 회원 탈퇴 시키는 API 를 개발했어요. 회원의 개인정보를 전부 null 처리하고 상태를 변경해줍니다.
- 엑세스 토큰을 활용해서 회원의 정보를 가져오는 API 를 개발했어요.
- 관련 작업 중에 에러 핸들링을 개발했어요.

## 📝 작업 유형
- [x] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 업데이트
- [ ] 단순 코드 스타일 변경 (세미콜론 추가 등)
- [ ] 배포 관련

## ✅ 체크리스트
- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] 해당 PR과 관련없는 변경사항이 없는가? (만약 있다면 제목이나 변경사항에 기술하여 주세요.)
- [x] 실행시 console 창에 에러나 경고가 없는것을 확인하였는가?
