### PR TITLE
fix: [#35] 필사 이미지 2장 이상 업로드 시 Exception

### DIFF
--- a/src/main/java/potenday/pilsa/global/exception/ExceptionCode.java
+++ b/src/main/java/potenday/pilsa/global/exception/ExceptionCode.java
@@ -13,6 +13,7 @@ public enum ExceptionCode {
 
     MAX_CATEGORY_SIZE(3001, "필사를 등록할때 카테고리는 최대 3개까지 선택할 수 있습니다."),
     NOT_INPUT_CONTENT(3002, "필사를 등록할때 필사 내용과 사진 중 하나는 필수로 등록해주세요."),
+    IMAGE_COUNT_MUST_ONE(3003, "필사를 등록할때 사진은 한장만 업로드 할 수 있습니다."),
 
     NOT_FOUND_PILSA_CATEGORY(2003, "필사카테고리를 찾을 수 없습니다."),
 

--- a/src/main/java/potenday/pilsa/pilsa/controller/PilsaController.java
+++ b/src/main/java/potenday/pilsa/pilsa/controller/PilsaController.java
@@ -70,7 +70,7 @@ public class PilsaController {
     @Operation(summary = "필사 수정", description = "")
     @PutMapping("{pilsaId}")
     public ResponseEntity<?> updatePilsaInfo(
-            @Auth Long memberId,
+            @Parameter(hidden = true) @Auth Long memberId,
             @PathVariable("pilsaId") Long pilsaId,
             @RequestBody @Valid RequestPilsaInfoDto request) {
         ResponsePilsaDetailDto responsePilsaDetailDto = pilsaService.updatePilsa(memberId, request, pilsaId);
@@ -83,7 +83,7 @@ public class PilsaController {
     @Operation(summary = "필사 삭제", description = "")
     @DeleteMapping("{pilsaId}")
     public ResponseEntity<Void> deletePilsaInfo(
-            @PathVariable Long pilsaId,
+            @Parameter(hidden = true) @PathVariable Long pilsaId,
             @Auth Long memberId) {
         pilsaService.deletePilsa(pilsaId, memberId);
 

--- a/src/main/java/potenday/pilsa/pilsa/service/PilsaService.java
+++ b/src/main/java/potenday/pilsa/pilsa/service/PilsaService.java
@@ -94,6 +94,7 @@ public class PilsaService {
 
     public Pilsa pilsaSave(RequestPilsaInfoDto request, Pilsa pilsa) {
         validationCategoryCount(request.getCategoryCd());
+        validationImageCount(request.getImages());
 
         List<PilsaCategory> categoryList = pilsaCategoryRepository.findByCategoryCdIn(request.getCategoryCd());
         List<RelationPilsaCategory> relationPilsaCategories = categoryList.stream()
@@ -123,6 +124,13 @@ public class PilsaService {
     private void validationCategoryCount(List<Long> categoryCd) {
         if (!categoryCd.isEmpty() && categoryCd.size() > 3) {
             throw new BadRequestException(ExceptionCode.MAX_CATEGORY_SIZE);
+        }
+    }
+
+    private void validationImageCount(List<ImageRequest> images) {
+        if (images != null && images.size() >= 2) {
+            throw new BadRequestException(ExceptionCode.IMAGE_COUNT_MUST_ONE);
+
         }
     }
 


### PR DESCRIPTION
## 🔥 관련 이슈
Issue: #35 

## ✨ 변경사항
- 필사 이미지 2장 이상 업로드 시 Exception

## 📝 작업 유형
- [ ] 신규 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서 업데이트
- [ ] 단순 코드 스타일 변경 (세미콜론 추가 등)
- [ ] 배포 관련

## ✅ 체크리스트
- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] 해당 PR과 관련없는 변경사항이 없는가? (만약 있다면 제목이나 변경사항에 기술하여 주세요.)
- [x] 실행시 console 창에 에러나 경고가 없는것을 확인하였는가?
