### PR TITLE
feat: [#63] 회원 정보 변경 API 기능

### DIFF
--- a/src/main/java/potenday/pilsa/member/controller/MemberController.java
+++ b/src/main/java/potenday/pilsa/member/controller/MemberController.java
@@ -36,7 +36,7 @@ public class MemberController {
         return ResponseEntity.ok(memberService.getMemberInfo(memberId));
     }
 
-    @Operation(summary = "회원의 소개글을 변경하는 API", description = "")
+    @Operation(summary = "회원의 정보를 변경하는 API", description = "")
     @PutMapping("/member")
     public ResponseEntity<MemberInfoResponse> modifyMemberInfo(
             @Parameter(hidden = true) @Auth Long memberId,
@@ -73,6 +73,7 @@ public class MemberController {
 
         return ResponseEntity.ok(tokenPair);
     }
+
 
 
 }

--- a/src/main/java/potenday/pilsa/member/domain/Member.java
+++ b/src/main/java/potenday/pilsa/member/domain/Member.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import potenday.pilsa.member.dto.request.MemberUpdateRequest;
 
 import java.time.LocalDateTime;
 
@@ -13,8 +14,7 @@ import java.time.LocalDateTime;
 @Table(name = "memberInfo")
 public class Member {
     private static final String DELETED_MEMBER_NICKNAME = "탈퇴회원";
-    // TODO : 나중에 다른 디폴트 이미지로 변경
-    private static final String DEFAULT_IMAGE = "https://weavers-siltarae.s3.ap-northeast-2.amazonaws.com/profile/default_image.png";
+    private static final String DEFAULT_IMAGE = "https://kr.object.ncloudstorage.com/pilsa-image/pilsa-content/profile_sample.png";
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -53,9 +53,21 @@ public class Member {
         this.status = Status.ACTIVE;
     }
 
-    public void updateDescription(String description) {
-        this.description = description;
+    public void updateDescription(MemberUpdateRequest updateRequest) {
+        this.description = updateRequest.getDescription();
+        this.profileNickName = updateRequest.getNickName();
+
+        if (updateRequest.getImageUrl().isEmpty()) {
+            setDefaultImage();
+        } else {
+            this.profileImageUrl = updateRequest.getImageUrl();
+        }
+
         this.updateDate = LocalDateTime.now();
+    }
+
+    private void setDefaultImage() {
+        this.profileImageUrl = DEFAULT_IMAGE;
     }
 
     public void deleteMember() {

--- a/src/main/java/potenday/pilsa/member/dto/request/MemberUpdateRequest.java
+++ b/src/main/java/potenday/pilsa/member/dto/request/MemberUpdateRequest.java
@@ -1,5 +1,9 @@
 package potenday.pilsa.member.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -10,11 +14,19 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class MemberUpdateRequest {
 
+    @Schema(description = "회원의 이미지 Url")
+    private String imageUrl;
+    @Schema(description = "회원의 닉네임")
+    @NotBlank(message = "닉네임은 필수 값 입니다.")
+    private String nickName;
+
     @Size(max = 100, message = "소개글은 최대 100자로 작성할 수 있습니다.")
     private String description;
 
     @Builder
-    public MemberUpdateRequest(String description) {
+    public MemberUpdateRequest(String imageUrl, String nickName, String description) {
+        this.imageUrl = imageUrl;
+        this.nickName = nickName;
         this.description = description;
     }
 }

--- a/src/main/java/potenday/pilsa/member/dto/request/MemberUpdateRequest.java
+++ b/src/main/java/potenday/pilsa/member/dto/request/MemberUpdateRequest.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -18,6 +19,7 @@ public class MemberUpdateRequest {
     private String imageUrl;
     @Schema(description = "회원의 닉네임")
     @NotBlank(message = "닉네임은 필수 값 입니다.")
+    @Pattern(regexp = "^[a-zA-Z0-9가-힣]{1,10}$", message = "닉네임은 숫자, 영어, 한글로 이루어진 10자 이내의 값이어야 합니다.")
     private String nickName;
 
     @Size(max = 100, message = "소개글은 최대 100자로 작성할 수 있습니다.")

--- a/src/main/java/potenday/pilsa/member/service/MemberService.java
+++ b/src/main/java/potenday/pilsa/member/service/MemberService.java
@@ -27,7 +27,7 @@ public class MemberService {
     @Transactional
     public MemberInfoResponse updateMember(Long memberId, MemberUpdateRequest request) {
         Member member = getMember(memberId);
-        member.updateDescription(request.getDescription());
+        member.updateDescription(request);
 
         return MemberInfoResponse.from(member);
     }


### PR DESCRIPTION
## 🔥 관련 이슈
Issue: #63 

## ✨ 변경사항
- 회원의 소개글 변경 API 가 회원의 정보를 변경하는 API 로 확장되었습니다.
- 회원의 프로필이미지가 없다면 디폴트 이미지로 변경됩니다.
- 회원의 닉네임은 필수 입니다.

## 📝 작업 유형
- [x] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 업데이트
- [ ] 단순 코드 스타일 변경 (세미콜론 추가 등)
- [ ] 배포 관련

## ✅ 체크리스트
- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] 해당 PR과 관련없는 변경사항이 없는가? (만약 있다면 제목이나 변경사항에 기술하여 주세요.)
- [x] 실행시 console 창에 에러나 경고가 없는것을 확인하였는가?
