### PR TITLE
feat: [#87] 챌린지 조회 시 카테고리 내용 포함 반환

### DIFF
--- a/src/main/java/potenday/pilsa/challenge/dto/response/ResponseChallengeInfo.java
+++ b/src/main/java/potenday/pilsa/challenge/dto/response/ResponseChallengeInfo.java
@@ -8,6 +8,7 @@ import lombok.NoArgsConstructor;
 import potenday.pilsa.challenge.domain.Challenge;
 import potenday.pilsa.challenge.domain.Status;
 import potenday.pilsa.global.util.LocalDateUtil;
+import potenday.pilsa.pilsaCategory.dto.response.ResponseCategoryListDto;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -31,9 +32,11 @@ public class ResponseChallengeInfo {
     private String description;
     @Schema(description = "상태 [SUCCESS : 성공, FAIL : 실패, ING : 진행중, EXPECTED : 예정]")
     private Status status;
+    @Schema(description = "카테고리 리스트")
+    private ResponseCategoryListDto categoryListDto;
 
     @Builder
-    public ResponseChallengeInfo(Long id, LocalDate startDate, LocalDate endDate, LocalDateTime registDate, String title, String description, Status status) {
+    public ResponseChallengeInfo(Long id, LocalDate startDate, LocalDate endDate, LocalDateTime registDate, String title, String description, Status status, ResponseCategoryListDto categoryListDto) {
         this.id = id;
         this.startDate = startDate;
         this.endDate = endDate;
@@ -41,6 +44,7 @@ public class ResponseChallengeInfo {
         this.title = title;
         this.description = description;
         this.status = status;
+        this.categoryListDto = categoryListDto;
     }
 
     public static ResponseChallengeInfo from(Challenge challenge) {
@@ -52,6 +56,7 @@ public class ResponseChallengeInfo {
                 .title(challenge.getTitle())
                 .description(challenge.getDescription())
                 .status(challenge.getStatus())
+                .categoryListDto(ResponseCategoryListDto.from(challenge.getCategories()))
                 .build();
     }
 


### PR DESCRIPTION
## 🔥 관련 이슈
Issue: Close #87

## ✨ 변경사항
- 챌린지 ResponseDto에 카테고리 내용을 포함하여 반환하기로 하였어요.

## 📝 작업 유형
- [x] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 업데이트
- [ ] 단순 코드 스타일 변경 (세미콜론 추가 등)
- [ ] 배포 관련

## ✅ 체크리스트
- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] 해당 PR과 관련없는 변경사항이 없는가? (만약 있다면 제목이나 변경사항에 기술하여 주세요.)
- [x] 실행시 console 창에 에러나 경고가 없는것을 확인하였는가?

## 추가 설명
없으면 생략 가능합니다.