### PR TITLE
feat: [#86] 필사 등록 시 챌린지 번호 함께 저장

### DIFF
--- a/src/main/java/potenday/pilsa/challenge/domain/Challenge.java
+++ b/src/main/java/potenday/pilsa/challenge/domain/Challenge.java
@@ -8,6 +8,7 @@ import potenday.pilsa.global.exception.BadRequestException;
 import potenday.pilsa.global.exception.ExceptionCode;
 import potenday.pilsa.global.util.LocalDateUtil;
 import potenday.pilsa.member.domain.Member;
+import potenday.pilsa.pilsa.domain.Pilsa;
 import potenday.pilsa.pilsaCategory.domain.PilsaCategory;
 
 import java.time.LocalDate;
@@ -59,6 +60,9 @@ public class Challenge {
             inverseJoinColumns = @JoinColumn(name = "category_id"),
             joinColumns = @JoinColumn(name = "challenge_id"))
     private List<PilsaCategory> categories;
+
+    @OneToMany(mappedBy = "challenge", cascade = CascadeType.ALL)
+    private List<Pilsa> pilsas;
 
     public Challenge(Member member, LocalDateTime startDate, LocalDateTime endDate, String title, String description, List<PilsaCategory> categories) {
         this.member = member;

--- a/src/main/java/potenday/pilsa/global/exception/ExceptionCode.java
+++ b/src/main/java/potenday/pilsa/global/exception/ExceptionCode.java
@@ -28,6 +28,7 @@ public enum ExceptionCode {
 
     FAIL_DATE_CHALLENGE(7001, "유효하지 않은 날짜 입니다."),
     NOT_FOUND_CHALLENGE(7002, "존재하지 않은 챌린지입니다."),
+    INVALID_CHALLENGE_PILSA_CATEGORY(7003, "챌린지 필사 등록 시 카테고리는 존재할 수 없습니다."),
 
     INTERNAL_SEVER_ERROR(9999, "서버 에러가 발생하였습니다. 관리자에게 문의해 주세요.");
 

--- a/src/main/java/potenday/pilsa/pilsa/domain/Pilsa.java
+++ b/src/main/java/potenday/pilsa/pilsa/domain/Pilsa.java
@@ -2,6 +2,7 @@ package potenday.pilsa.pilsa.domain;
 
 import jakarta.persistence.*;
 import lombok.*;
+import potenday.pilsa.challenge.domain.Challenge;
 import potenday.pilsa.global.exception.BadRequestException;
 import potenday.pilsa.global.exception.ExceptionCode;
 import potenday.pilsa.like.domain.Like;
@@ -82,6 +83,10 @@ public class Pilsa {
 
     @OneToMany(mappedBy = "pilsa", cascade = CascadeType.DETACH)
     private List<Like> likes;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "challengeId")
+    private Challenge challenge;
 
     @Builder
     public Pilsa(String title, Member member,String author, String publisher, String textContents, String backgroundImageUrl, String backgroundColor, RequestPilsaInfoDto requestPilsaInfoDto) {

--- a/src/main/java/potenday/pilsa/pilsa/domain/Pilsa.java
+++ b/src/main/java/potenday/pilsa/pilsa/domain/Pilsa.java
@@ -89,8 +89,9 @@ public class Pilsa {
     private Challenge challenge;
 
     @Builder
-    public Pilsa(String title, Member member,String author, String publisher, String textContents, String backgroundImageUrl, String backgroundColor, RequestPilsaInfoDto requestPilsaInfoDto) {
+    public Pilsa(String title, Member member,String author, String publisher, String textContents, String backgroundImageUrl, String backgroundColor, RequestPilsaInfoDto requestPilsaInfoDto, Challenge challenge) {
         validationContent(requestPilsaInfoDto.getImages(), textContents);
+        validationChallengeCategory(challenge, requestPilsaInfoDto);
 
         this.title = title;
         this.member = member;
@@ -102,6 +103,7 @@ public class Pilsa {
         this.backgroundColor = backgroundColor;
         this.backgroundImageUrl = backgroundImageUrl;
         this.registDate = LocalDateTime.now();
+        this.challenge = challenge;
 
         if (!requestPilsaInfoDto.getImages().isEmpty()) {
             this.status = (textContents != null) ? Status.ALL : Status.IMG;
@@ -151,6 +153,12 @@ public class Pilsa {
     private void validationContent(List<ImageRequest> images, String textContents) {
         if (images.isEmpty() && textContents.isBlank()) {
             throw new BadRequestException(ExceptionCode.NOT_INPUT_CONTENT);
+        }
+    }
+
+    private void validationChallengeCategory(Challenge challenge, RequestPilsaInfoDto request) {
+        if (challenge != null && !request.getCategoryCd().isEmpty()) {
+            throw new BadRequestException(ExceptionCode.INVALID_CHALLENGE_PILSA_CATEGORY);
         }
     }
 }

--- a/src/main/java/potenday/pilsa/pilsa/dto/request/RequestPilsaInfoDto.java
+++ b/src/main/java/potenday/pilsa/pilsa/dto/request/RequestPilsaInfoDto.java
@@ -2,6 +2,7 @@ package potenday.pilsa.pilsa.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.*;
 import potenday.pilsa.pilsa.domain.YN;
 import potenday.pilsa.pilsaImage.dto.request.ImageRequest;
@@ -34,6 +35,8 @@ public class RequestPilsaInfoDto {
     @Schema(description = "필사 카테고리 코드 리스트")
     private List<Long> categoryCd;
     @Schema(description = "이미지 정보 리스트")
+    @NotNull(message = "이미지 정보는 빈값일 수 없습니다.")
     private List<ImageRequest> images;
-
+    @Schema(description = "챌린지 번호")
+    private Long challengeId;
 }

--- a/src/main/java/potenday/pilsa/pilsa/service/PilsaService.java
+++ b/src/main/java/potenday/pilsa/pilsa/service/PilsaService.java
@@ -5,6 +5,8 @@ import lombok.ToString;
 import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import potenday.pilsa.challenge.domain.Challenge;
+import potenday.pilsa.challenge.domain.repository.ChallengeRepository;
 import potenday.pilsa.global.dto.request.RequestPageDto;
 import potenday.pilsa.global.exception.BadRequestException;
 import potenday.pilsa.global.exception.ExceptionCode;
@@ -49,6 +51,7 @@ public class PilsaService {
     private final PilsaImageRepository pilsaImageRepository;
     private final RelationPilsaCategoryRepository relationPilsaCategoryRepository;
     private final LikeRepository likeRepository;
+    private final ChallengeRepository challengeRepository;
 
     @Transactional(readOnly = true)
     public ResponsePilsaListDto getAllPilsalList(RequestPilsaList request, Long memberId) {
@@ -107,6 +110,7 @@ public class PilsaService {
     @Transactional
     public Long createPilsa(Long memberId, RequestPilsaInfoDto request) {
         Member member = getMember(memberId);
+        Challenge challenge = (request.getChallengeId() != null) ? getChallenge(memberId, request.getChallengeId()) : null;
 
         Pilsa pilsa = new Pilsa(
                 request.getTitle(),
@@ -116,7 +120,8 @@ public class PilsaService {
                 request.getTextContents(),
                 request.getBackgroundImageUrl(),
                 request.getBackgroundColor(),
-                request);
+                request,
+                challenge);
 
         return pilsaSave(request, pilsa).getPilsaId();
     }
@@ -186,6 +191,12 @@ public class PilsaService {
     private Member getMember(Long memberId) {
         return memberRepository.findByIdAndStatus(memberId, Status.ACTIVE).orElseThrow(
                 () -> new BadRequestException(ExceptionCode.NOT_FOUND_MEMBER)
+        );
+    }
+
+    private Challenge getChallenge(Long memberId, Long challengeId) {
+        return challengeRepository.findByMember_IdAndDeleteDateIsNullAndId(memberId, challengeId).orElseThrow(
+                () -> new BadRequestException(ExceptionCode.NOT_FOUND_CHALLENGE)
         );
     }
 


### PR DESCRIPTION
## 🔥 관련 이슈

Issue: #86 

## ✨ 변경사항
- 필사 등록 시 챌린지 번호 추가 등록
- 필사 : 챌린지 N:1 관계 연결
- 필사 등록 시 챌린지 번호와 카테고리가 동시에 들어올 경우 Exception

## 📝 작업 유형
- [x] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 업데이트
- [ ] 단순 코드 스타일 변경 (세미콜론 추가 등)
- [ ] 배포 관련

## ✅ 체크리스트
- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] 해당 PR과 관련없는 변경사항이 없는가? (만약 있다면 제목이나 변경사항에 기술하여 주세요.)
- [x] 실행시 console 창에 에러나 경고가 없는것을 확인하였는가?