### PR TITLE
feat: [#91] 챌린지 상태를 성공과 실패로 나뉘어서 변화

### DIFF
--- a/src/main/java/potenday/pilsa/challenge/controller/ChallengeController.java
+++ b/src/main/java/potenday/pilsa/challenge/controller/ChallengeController.java
@@ -67,9 +67,10 @@ public class ChallengeController {
 
     @Operation(summary = "진행중인 챌린지의 상태를 성공과 실패로 나누어서 변화시키는 API")
     @PostMapping("/change-statue")
-    public ResponseEntity<List<ResponseChallengeInfo>> changeStatue(
+    public ResponseEntity<Void> changeStatue(
             @Parameter(hidden = true) @Auth Long memberId) {
 
-        return ResponseEntity.ok(challengeService.changeINGStatueSuccessOrFail(memberId));
+        challengeService.changeINGStatueSuccessOrFail(memberId);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/potenday/pilsa/challenge/service/ChallengeService.java
+++ b/src/main/java/potenday/pilsa/challenge/service/ChallengeService.java
@@ -78,19 +78,15 @@ public class ChallengeService {
     }
 
     @Transactional
-    public List<ResponseChallengeInfo> changeINGStatueSuccessOrFail(Long memberId) {
+    public void changeINGStatueSuccessOrFail(Long memberId) {
         LocalDateTime startDate =  LocalDateUtil.startLocalDateToTime(LocalDate.now());
         LocalDateTime endDate = LocalDateUtil.endLocalDateToTime(LocalDate.now());
 
         List<Challenge> challenges = challengeRepository.findByMember_IdAndDeleteDateIsNullAndStatusAndEndDateIsBetween(memberId, ING, startDate, endDate);
 
-        if (challenges.isEmpty()) {
-            return new ArrayList<>();
-        }
-
         challenges.forEach(
                 challenge -> {
-                    long pilsaCount = pilsaRepository.findByMember_IdAndRegistDateBetweenAndDeleteDateIsNull(memberId, challenge.getStartDate(), challenge.getEndDate())
+                    long pilsaCount = pilsaRepository.findByMember_IdAndChallenge_IdAndDeleteDateIsNull(memberId, challenge.getId())
                             .stream()
                             .map(pilsa -> pilsa.getRegistDate().toLocalDate())
                             .distinct()
@@ -99,8 +95,6 @@ public class ChallengeService {
                     challenge.changeStatueSuccessOrFail(pilsaCount);
                 }
         );
-
-        return ResponseChallengeInfo.from(challenges);
     }
 
     @Transactional

--- a/src/main/java/potenday/pilsa/pilsa/domain/repository/PilsaRepository.java
+++ b/src/main/java/potenday/pilsa/pilsa/domain/repository/PilsaRepository.java
@@ -28,5 +28,6 @@ public interface PilsaRepository extends JpaRepository<Pilsa, Long>, PilsaQRepos
     List<Pilsa> findByMember_IdAndRegistDateBetweenAndDeleteDateIsNullOrderByRegistDateAsc(Long member_id, LocalDateTime startDate, LocalDateTime endDate);
 
     List<Pilsa> findByMember_IdAndRegistDateBetweenAndDeleteDateIsNull(Long member_id, LocalDateTime registDate, LocalDateTime registDate2);
+    List<Pilsa> findByMember_IdAndChallenge_IdAndDeleteDateIsNull(Long member_id, Long challenge_id);
 
 }


### PR DESCRIPTION
## 🔥 관련 이슈
Issue: #91 

## ✨ 변경사항
- 챌린지의 상태를 성공과 실패로 나뉘어서 변화시키는 로직을 수정했어요.

## 📝 작업 유형
- [x] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 업데이트
- [ ] 단순 코드 스타일 변경 (세미콜론 추가 등)
- [ ] 배포 관련

## ✅ 체크리스트
- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] 해당 PR과 관련없는 변경사항이 없는가? (만약 있다면 제목이나 변경사항에 기술하여 주세요.)
- [x] 실행시 console 창에 에러나 경고가 없는것을 확인하였는가?