### PR TITLE
feat: [#93] 챌린지 달성률 추가 반환

### DIFF
--- a/src/main/java/potenday/pilsa/challenge/domain/Challenge.java
+++ b/src/main/java/potenday/pilsa/challenge/domain/Challenge.java
@@ -96,10 +96,7 @@ public class Challenge {
     }
 
     public void changeStatueSuccessOrFail(Long pilsaCount) {
-        LocalDate startDate = LocalDateUtil.localDateTimeToDate(this.startDate);
-        LocalDate endDate = LocalDateUtil.localDateTimeToDate(this.endDate);
-
-        long daysBetween = ChronoUnit.DAYS.between(startDate, endDate) + 1;
+        long daysBetween = calculateDaysBetween(LocalDateUtil.localDateTimeToDate(this.startDate), LocalDateUtil.localDateTimeToDate(this.endDate));
 
         if (daysBetween == pilsaCount) {
             this.status = Status.SUCCESS;
@@ -107,4 +104,39 @@ public class Challenge {
             this.status = Status.FAIL;
         }
     }
+
+    public static long calculateDaysBetween(LocalDate startDate, LocalDate endDate) {
+        return ChronoUnit.DAYS.between(startDate, endDate) + 1;
+    }
+
+    public Integer calculateChallengeAchievementRate(Challenge challenge) {
+        List<Pilsa> pilsas = challenge.getPilsas();
+
+        // 삭제된 필사 제외
+        removeDeletedPilsas(pilsas);
+
+        // 필사 등록 날짜를 기준으로 중복 제거 후 개수 구하기
+        long pilsaCount = countDistinctRegistrationDates(pilsas);
+
+        return challenge.calculateAchievementRateBasedOnPilsa(pilsaCount);
+    }
+
+    public int calculateAchievementRateBasedOnPilsa(Long pilsaCount) {
+        long daysBetween = calculateDaysBetween(LocalDateUtil.localDateTimeToDate(this.startDate), LocalDateUtil.localDateTimeToDate(this.endDate));
+
+        double rate = (double) pilsaCount / daysBetween * 100;
+        return (int) Math.round(rate);
+    }
+
+    private static void removeDeletedPilsas(List<Pilsa> pilsas) {
+        pilsas.removeIf(pilsa -> pilsa.getDeleteDate() != null);
+    }
+
+    public static long countDistinctRegistrationDates(List<Pilsa> pilsas) {
+        return pilsas.stream()
+                .map(pilsa -> pilsa.getRegistDate().toLocalDate())
+                .distinct()
+                .count();
+    }
+
 }

--- a/src/main/java/potenday/pilsa/challenge/dto/response/ResponseChallengeInfo.java
+++ b/src/main/java/potenday/pilsa/challenge/dto/response/ResponseChallengeInfo.java
@@ -8,6 +8,7 @@ import lombok.NoArgsConstructor;
 import potenday.pilsa.challenge.domain.Challenge;
 import potenday.pilsa.challenge.domain.Status;
 import potenday.pilsa.global.util.LocalDateUtil;
+import potenday.pilsa.pilsa.domain.Pilsa;
 import potenday.pilsa.pilsaCategory.dto.response.ResponseCategoryListDto;
 
 import java.time.LocalDate;
@@ -35,8 +36,11 @@ public class ResponseChallengeInfo {
     @Schema(description = "카테고리 리스트")
     private ResponseCategoryListDto categoryListDto;
 
+    @Schema(description = "달성률")
+    private Integer achievementRate;
+
     @Builder
-    public ResponseChallengeInfo(Long id, LocalDate startDate, LocalDate endDate, LocalDateTime registDate, String title, String description, Status status, ResponseCategoryListDto categoryListDto) {
+    public ResponseChallengeInfo(Long id, LocalDate startDate, LocalDate endDate, LocalDateTime registDate, String title, String description, Status status, ResponseCategoryListDto categoryListDto, Integer achievementRate) {
         this.id = id;
         this.startDate = startDate;
         this.endDate = endDate;
@@ -45,6 +49,7 @@ public class ResponseChallengeInfo {
         this.description = description;
         this.status = status;
         this.categoryListDto = categoryListDto;
+        this.achievementRate = achievementRate;
     }
 
     public static ResponseChallengeInfo from(Challenge challenge) {
@@ -57,6 +62,7 @@ public class ResponseChallengeInfo {
                 .description(challenge.getDescription())
                 .status(challenge.getStatus())
                 .categoryListDto(ResponseCategoryListDto.from(challenge.getCategories()))
+                .achievementRate(challenge.calculateChallengeAchievementRate(challenge))
                 .build();
     }
 

--- a/src/main/java/potenday/pilsa/challenge/service/ChallengeService.java
+++ b/src/main/java/potenday/pilsa/challenge/service/ChallengeService.java
@@ -86,11 +86,7 @@ public class ChallengeService {
 
         challenges.forEach(
                 challenge -> {
-                    long pilsaCount = pilsaRepository.findByMember_IdAndChallenge_IdAndDeleteDateIsNull(memberId, challenge.getId())
-                            .stream()
-                            .map(pilsa -> pilsa.getRegistDate().toLocalDate())
-                            .distinct()
-                            .count();
+                    long pilsaCount = Challenge.countDistinctRegistrationDates(pilsaRepository.findByMember_IdAndChallenge_IdAndDeleteDateIsNull(memberId, challenge.getId()));
 
                     challenge.changeStatueSuccessOrFail(pilsaCount);
                 }


### PR DESCRIPTION
## 🔥 관련 이슈
Issue: #93 

## ✨ 변경사항
- 챌린지 조회 시 달성률을 추가해서 반환해요.
- 달성률은 백분률의 형태로 소수점없이 반올림하여 반환합니다.
- 관련 로직들이 Challenge 도메인내부에 있어서 같은 내용의 메소드를 사용하는 경우, 이 부분을 Service에서 도메인 내부로 위치를 변경하였어요.

## 📝 작업 유형
- [x] 신규 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 문서 업데이트
- [ ] 단순 코드 스타일 변경 (세미콜론 추가 등)
- [ ] 배포 관련

## ✅ 체크리스트
- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] 해당 PR과 관련없는 변경사항이 없는가? (만약 있다면 제목이나 변경사항에 기술하여 주세요.)
- [x] 실행시 console 창에 에러나 경고가 없는것을 확인하였는가?