### PR TITLE
feat: [#97] 챌린지 진행상태에 따라서 검색 조건 추가

### DIFF
--- a/src/main/java/potenday/pilsa/challenge/controller/ChallengeController.java
+++ b/src/main/java/potenday/pilsa/challenge/controller/ChallengeController.java
@@ -7,16 +7,15 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import potenday.pilsa.challenge.dto.request.RequestChallengeList;
 import potenday.pilsa.challenge.dto.request.RequestCreateChallenge;
 import potenday.pilsa.challenge.dto.request.RequestModifyChallenge;
 import potenday.pilsa.challenge.dto.response.ResponseChallengeInfo;
 import potenday.pilsa.challenge.dto.response.ResponseChallengeList;
 import potenday.pilsa.challenge.service.ChallengeService;
-import potenday.pilsa.global.dto.request.RequestPageDto;
 import potenday.pilsa.login.Auth;
 
 import java.net.URI;
-import java.util.List;
 
 @Tag(name = "챌린지")
 @RestController
@@ -50,7 +49,7 @@ public class ChallengeController {
     @GetMapping("/list")
     public ResponseEntity<ResponseChallengeList> getChallengeList(
             @Parameter(hidden = true) @Auth Long memberId,
-            @Valid RequestPageDto requestPageDto) {
+            @Valid RequestChallengeList requestPageDto) {
 
         return ResponseEntity.ok(challengeService.getChallengeList(memberId, requestPageDto));
     }

--- a/src/main/java/potenday/pilsa/challenge/domain/Challenge.java
+++ b/src/main/java/potenday/pilsa/challenge/domain/Challenge.java
@@ -5,6 +5,7 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import potenday.pilsa.challenge.dto.request.RequestModifyChallenge;
+import potenday.pilsa.challenge.dto.request.RequestStatus;
 import potenday.pilsa.global.exception.BadRequestException;
 import potenday.pilsa.global.exception.ExceptionCode;
 import potenday.pilsa.global.util.LocalDateUtil;
@@ -15,6 +16,7 @@ import potenday.pilsa.pilsaCategory.domain.PilsaCategory;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
 import java.util.List;
 
 @Entity
@@ -151,6 +153,16 @@ public class Challenge {
 
     private void modifyDescription(String description) {
         if (description != null && !description.isBlank()) this.description = description;
+    }
+
+    public static List<Status> mapRequestStatusToDomainStatus(List<RequestStatus> requestStatuses) {
+        List<Status> statuses = new ArrayList<>();
+        if (requestStatuses != null) {
+            for (RequestStatus reqStatus : requestStatuses) {
+                statuses.addAll(reqStatus.getMappedStatuses());
+            }
+        }
+        return statuses;
     }
 
 }

--- a/src/main/java/potenday/pilsa/challenge/domain/repository/ChallengeRepository.java
+++ b/src/main/java/potenday/pilsa/challenge/domain/repository/ChallengeRepository.java
@@ -7,13 +7,12 @@ import potenday.pilsa.challenge.domain.Challenge;
 import potenday.pilsa.challenge.domain.Status;
 
 import java.time.LocalDateTime;
-import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
 public interface ChallengeRepository extends JpaRepository<Challenge, Long> {
     Optional<Challenge> findByMember_IdAndDeleteDateIsNullAndId(Long memberId, Long id);
-    Page<Challenge> findByMember_IdAndDeleteDateIsNullOrderByRegistDateDesc(Long memberId, Pageable pageable);
+    Page<Challenge> findByMember_IdAndDeleteDateIsNullAndStatusInOrderByRegistDateDesc(Long memberId, List<Status> statuses,Pageable pageable);
     List<Challenge> findByDeleteDateIsNullAndStatusAndStartDateIsBefore(Status status, LocalDateTime startDate);
     List<Challenge> findByMember_IdAndDeleteDateIsNullAndStatusAndEndDateIsBetween(Long memberId, Status status, LocalDateTime endDate, LocalDateTime endDate2);
 }

--- a/src/main/java/potenday/pilsa/challenge/dto/request/RequestChallengeList.java
+++ b/src/main/java/potenday/pilsa/challenge/dto/request/RequestChallengeList.java
@@ -1,0 +1,22 @@
+package potenday.pilsa.challenge.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import potenday.pilsa.global.dto.request.RequestPageDto;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RequestChallengeList extends RequestPageDto {
+
+    @Schema(description = "챌린지 상태 조회 [ING: 진행중, END:진행종료, EXPECTED:진행예정]")
+    private List<RequestStatus> status;
+
+    public RequestChallengeList(Integer page, Integer size, List<RequestStatus> status) {
+        super(page, size);
+        this.status = status;
+    }
+}

--- a/src/main/java/potenday/pilsa/challenge/dto/request/RequestStatus.java
+++ b/src/main/java/potenday/pilsa/challenge/dto/request/RequestStatus.java
@@ -1,0 +1,22 @@
+package potenday.pilsa.challenge.dto.request;
+
+import potenday.pilsa.challenge.domain.Status;
+
+import java.util.Collections;
+import java.util.List;
+
+public enum RequestStatus {
+    ING(Collections.singletonList(Status.ING)),
+    EXPECTED(Collections.singletonList(Status.EXPECTED)),
+    END(List.of(Status.FAIL, Status.SUCCESS));
+
+    private final List<Status> mappedStatuses;
+
+    RequestStatus(List<Status> mappedStatuses) {
+        this.mappedStatuses = mappedStatuses;
+    }
+
+    public List<Status> getMappedStatuses() {
+        return this.mappedStatuses;
+    }
+}

--- a/src/main/java/potenday/pilsa/challenge/service/ChallengeService.java
+++ b/src/main/java/potenday/pilsa/challenge/service/ChallengeService.java
@@ -6,11 +6,11 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import potenday.pilsa.challenge.domain.Challenge;
 import potenday.pilsa.challenge.domain.repository.ChallengeRepository;
+import potenday.pilsa.challenge.dto.request.RequestChallengeList;
 import potenday.pilsa.challenge.dto.request.RequestCreateChallenge;
 import potenday.pilsa.challenge.dto.request.RequestModifyChallenge;
 import potenday.pilsa.challenge.dto.response.ResponseChallengeInfo;
 import potenday.pilsa.challenge.dto.response.ResponseChallengeList;
-import potenday.pilsa.global.dto.request.RequestPageDto;
 import potenday.pilsa.global.exception.BadRequestException;
 import potenday.pilsa.global.exception.ExceptionCode;
 import potenday.pilsa.global.util.LocalDateUtil;
@@ -24,7 +24,6 @@ import potenday.pilsa.pilsaCategory.domain.repository.PilsaCategoryRepository;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.util.ArrayList;
 import java.util.List;
 
 import static potenday.pilsa.challenge.domain.Status.EXPECTED;
@@ -64,8 +63,10 @@ public class ChallengeService {
     }
 
     @Transactional(readOnly = true)
-    public ResponseChallengeList getChallengeList(Long memberId, RequestPageDto requestPageDto) {
-        Page<Challenge> challenges = challengeRepository.findByMember_IdAndDeleteDateIsNullOrderByRegistDateDesc(memberId, requestPageDto.toPageable());
+    public ResponseChallengeList getChallengeList(Long memberId, RequestChallengeList request) {
+        List<potenday.pilsa.challenge.domain.Status> statuses = Challenge.mapRequestStatusToDomainStatus(request.getStatus());
+
+        Page<Challenge> challenges = challengeRepository.findByMember_IdAndDeleteDateIsNullAndStatusInOrderByRegistDateDesc(memberId, statuses, request.toPageable());
         changeINGStatueSuccessOrFail(memberId);
 
         return ResponseChallengeList.from(challenges);


### PR DESCRIPTION
## 🔥 관련 이슈

Issue: #97 

## ✨ 변경사항
- 챌린지 진행 상태에 따라서 검색 조건 추가
- 진행예정, 진행중, 진행종료에 따라서 중복 검색이 가능합니다.

## 📝 작업 유형
- [x] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 업데이트
- [ ] 단순 코드 스타일 변경 (세미콜론 추가 등)
- [ ] 배포 관련

## ✅ 체크리스트
- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] 해당 PR과 관련없는 변경사항이 없는가? (만약 있다면 제목이나 변경사항에 기술하여 주세요.)
- [x] 실행시 console 창에 에러나 경고가 없는것을 확인하였는가?