### PR TITLE
feat: [#98] 필사 조회 시 챌린지가 있다면 관련 정보 Response 에 추가

### DIFF
--- a/src/main/java/potenday/pilsa/pilsa/dto/response/ResponsePilsaDetailDto.java
+++ b/src/main/java/potenday/pilsa/pilsa/dto/response/ResponsePilsaDetailDto.java
@@ -5,6 +5,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import potenday.pilsa.challenge.domain.Challenge;
 import potenday.pilsa.member.dto.response.MemberInfoResponse;
 import potenday.pilsa.pilsa.domain.Pilsa;
 import potenday.pilsa.pilsa.domain.YN;
@@ -48,9 +49,13 @@ public class ResponsePilsaDetailDto {
     private Boolean isLikedAble;
     @Schema(description = "좋아요 개수")
     private Integer likeCount;
+    @Schema(description = "챌린지 필사 여부 (true: 챌린지 필사, false: 챌린지 필사가 아닌 일반 필사)")
+    private Boolean isChallenge;
+    @Schema(description = "챌린지 필사 일 경우 챌린지 제목")
+    private String challengeTitle;
 
     @Builder
-    public ResponsePilsaDetailDto(Long pilsaId, String title, String author, String publisher, YN privateType, String textContents, String backgroundImageUrl, String backgroundColor, LocalDateTime registDate, LocalDateTime updateDate, List<ResponseCategoryDto> categoryLists, List<ResponseImagetDto> pilsaImages, MemberInfoResponse memberInfoResponse, Boolean isLikedAble, Integer likeCount) {
+    public ResponsePilsaDetailDto(Long pilsaId, String title, String author, String publisher, YN privateType, String textContents, String backgroundImageUrl, String backgroundColor, LocalDateTime registDate, LocalDateTime updateDate, List<ResponseCategoryDto> categoryLists, List<ResponseImagetDto> pilsaImages, MemberInfoResponse memberInfoResponse, Boolean isLikedAble, Integer likeCount, Boolean isChallenge, String challengeTitle) {
         this.pilsaId = pilsaId;
         this.title = title;
         this.author = author;
@@ -66,6 +71,8 @@ public class ResponsePilsaDetailDto {
         this.memberInfoResponse = memberInfoResponse;
         this.isLikedAble = isLikedAble;
         this.likeCount = likeCount;
+        this.isChallenge = isChallenge;
+        this.challengeTitle = challengeTitle;
     }
 
     public static ResponsePilsaDetailDto from(Pilsa pilsa, Boolean isLikedAble) {
@@ -78,6 +85,8 @@ public class ResponsePilsaDetailDto {
                 .stream()
                 .map(ResponseImagetDto::from)
                 .toList();
+
+        Challenge challenge = pilsa.getChallenge();
 
         return ResponsePilsaDetailDto.builder()
                 .pilsaId(pilsa.getPilsaId())
@@ -95,6 +104,8 @@ public class ResponsePilsaDetailDto {
                 .pilsaImages(responseImagetDtos)
                 .isLikedAble(isLikedAble)
                 .likeCount(pilsa.getLikes().size())
+                .isChallenge(challenge != null)
+                .challengeTitle(challenge != null ? challenge.getTitle() : null)
                 .build();
     }
 }

--- a/src/main/java/potenday/pilsa/pilsa/dto/response/ResponsePilsaDetailDto.java
+++ b/src/main/java/potenday/pilsa/pilsa/dto/response/ResponsePilsaDetailDto.java
@@ -53,9 +53,11 @@ public class ResponsePilsaDetailDto {
     private Boolean isChallenge;
     @Schema(description = "챌린지 필사 일 경우 챌린지 제목")
     private String challengeTitle;
+    @Schema(description = "챌린지 번호")
+    private Long challengeId;
 
     @Builder
-    public ResponsePilsaDetailDto(Long pilsaId, String title, String author, String publisher, YN privateType, String textContents, String backgroundImageUrl, String backgroundColor, LocalDateTime registDate, LocalDateTime updateDate, List<ResponseCategoryDto> categoryLists, List<ResponseImagetDto> pilsaImages, MemberInfoResponse memberInfoResponse, Boolean isLikedAble, Integer likeCount, Boolean isChallenge, String challengeTitle) {
+    public ResponsePilsaDetailDto(Long pilsaId, String title, String author, String publisher, YN privateType, String textContents, String backgroundImageUrl, String backgroundColor, LocalDateTime registDate, LocalDateTime updateDate, List<ResponseCategoryDto> categoryLists, List<ResponseImagetDto> pilsaImages, MemberInfoResponse memberInfoResponse, Boolean isLikedAble, Integer likeCount, Boolean isChallenge, String challengeTitle, Long challengeId) {
         this.pilsaId = pilsaId;
         this.title = title;
         this.author = author;
@@ -73,6 +75,7 @@ public class ResponsePilsaDetailDto {
         this.likeCount = likeCount;
         this.isChallenge = isChallenge;
         this.challengeTitle = challengeTitle;
+        this.challengeId = challengeId;
     }
 
     public static ResponsePilsaDetailDto from(Pilsa pilsa, Boolean isLikedAble) {
@@ -106,6 +109,7 @@ public class ResponsePilsaDetailDto {
                 .likeCount(pilsa.getLikes().size())
                 .isChallenge(challenge != null)
                 .challengeTitle(challenge != null ? challenge.getTitle() : null)
+                .challengeId(challenge != null ? challenge.getId() : null)
                 .build();
     }
 }


### PR DESCRIPTION
## 🔥 관련 이슈
Issue: #98 

## ✨ 변경사항
- 필사 상세 조회 시 챌린지 정보가 있다면 Response 에 챌린지 제목을 추가하였어요.
- 챌린지 번호도 추가하였어요.

## 📝 작업 유형
- [x] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 업데이트
- [ ] 단순 코드 스타일 변경 (세미콜론 추가 등)
- [ ] 배포 관련

## ✅ 체크리스트
- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] 해당 PR과 관련없는 변경사항이 없는가? (만약 있다면 제목이나 변경사항에 기술하여 주세요.)
- [x] 실행시 console 창에 에러나 경고가 없는것을 확인하였는가?
