### PR TITLE
feat: [#101] 챌린지번호와 날짜를 통해서 필사 리스트를 조회 

### DIFF
--- a/src/main/java/potenday/pilsa/challenge/controller/ChallengeController.java
+++ b/src/main/java/potenday/pilsa/challenge/controller/ChallengeController.java
@@ -8,10 +8,13 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import potenday.pilsa.challenge.dto.request.RequestChallengeList;
+import potenday.pilsa.challenge.dto.request.RequestChallengePilsa;
 import potenday.pilsa.challenge.dto.request.RequestCreateChallenge;
 import potenday.pilsa.challenge.dto.request.RequestModifyChallenge;
 import potenday.pilsa.challenge.dto.response.ResponseChallengeInfo;
 import potenday.pilsa.challenge.dto.response.ResponseChallengeList;
+import potenday.pilsa.challenge.dto.response.ResponseChallengePilsaInfo;
+import potenday.pilsa.challenge.dto.response.ResponseChallengePilsaInfoList;
 import potenday.pilsa.challenge.service.ChallengeService;
 import potenday.pilsa.login.Auth;
 
@@ -85,4 +88,14 @@ public class ChallengeController {
 
         return ResponseEntity.created(URI.create("challenge/" + challengeId)).build();
     }
+
+    @Operation(summary = "챌린지에 해당하는 필사 리스트 조회")
+    @GetMapping("/pilsa")
+    public ResponseEntity<ResponseChallengePilsaInfoList> getChallengePilsas(
+            @Parameter(hidden = true) @Auth Long memberId,
+            @Valid RequestChallengePilsa requestChallengePilsa) {
+
+        return ResponseEntity.ok(challengeService.getChallengePilsa(memberId, requestChallengePilsa));
+    }
+
 }

--- a/src/main/java/potenday/pilsa/challenge/dto/request/RequestChallengePilsa.java
+++ b/src/main/java/potenday/pilsa/challenge/dto/request/RequestChallengePilsa.java
@@ -1,0 +1,23 @@
+package potenday.pilsa.challenge.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RequestChallengePilsa {
+    @NotNull(message = "챌린지 번호는 빈값일 수 없습니다.")
+    private Long challengeId;
+    private LocalDate localDate;
+
+    @Builder
+    public RequestChallengePilsa(Long challengeId, LocalDate localDate) {
+        this.challengeId = challengeId;
+        this.localDate = localDate;
+    }
+}

--- a/src/main/java/potenday/pilsa/challenge/dto/response/ResponseChallengePilsaInfo.java
+++ b/src/main/java/potenday/pilsa/challenge/dto/response/ResponseChallengePilsaInfo.java
@@ -1,0 +1,45 @@
+package potenday.pilsa.challenge.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import potenday.pilsa.pilsa.domain.Pilsa;
+import potenday.pilsa.pilsaImage.dto.response.ResponseImageListDto;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ResponseChallengePilsaInfo {
+    @Schema(description = "필사 아이디")
+    private Long id;
+    @Schema(description = "필사 제목")
+    private String title;
+    @Schema(description = "필사 콘텐츠 문구")
+    private String textContents;
+    @Schema(description = "필사 등록 날짜")
+    private LocalDateTime registDate;
+    @Schema(description = "이미지 리스트")
+    private ResponseImageListDto pilsaImages;
+
+    @Builder
+    public ResponseChallengePilsaInfo(Long id, String title, String textContents, LocalDateTime registDate, ResponseImageListDto pilsaImages) {
+        this.id = id;
+        this.title = title;
+        this.textContents = textContents;
+        this.registDate = registDate;
+        this.pilsaImages = pilsaImages;
+    }
+
+    public static ResponseChallengePilsaInfo from(Pilsa pilsa) {
+        return ResponseChallengePilsaInfo.builder()
+                .id(pilsa.getPilsaId())
+                .title(pilsa.getTitle())
+                .textContents(pilsa.getTextContents())
+                .registDate(pilsa.getRegistDate())
+                .pilsaImages(ResponseImageListDto.from(pilsa.getPilsaImages()))
+                .build();
+    }
+}

--- a/src/main/java/potenday/pilsa/challenge/dto/response/ResponseChallengePilsaInfoList.java
+++ b/src/main/java/potenday/pilsa/challenge/dto/response/ResponseChallengePilsaInfoList.java
@@ -1,0 +1,30 @@
+package potenday.pilsa.challenge.dto.response;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import potenday.pilsa.pilsa.domain.Pilsa;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ResponseChallengePilsaInfoList {
+    private List<ResponseChallengePilsaInfo> responseChallengePilsaInfos;
+
+    @Builder
+    public ResponseChallengePilsaInfoList(List<ResponseChallengePilsaInfo> responseChallengePilsaInfos) {
+        this.responseChallengePilsaInfos = responseChallengePilsaInfos;
+    }
+
+    public static ResponseChallengePilsaInfoList from(List<Pilsa> pilsas) {
+        List<ResponseChallengePilsaInfo> responsePilsas = pilsas.stream()
+                .map(ResponseChallengePilsaInfo::from)
+                .toList();
+
+        return ResponseChallengePilsaInfoList.builder()
+                .responseChallengePilsaInfos(responsePilsas)
+                .build();
+    }
+}

--- a/src/main/java/potenday/pilsa/challenge/service/ChallengeService.java
+++ b/src/main/java/potenday/pilsa/challenge/service/ChallengeService.java
@@ -7,16 +7,20 @@ import org.springframework.transaction.annotation.Transactional;
 import potenday.pilsa.challenge.domain.Challenge;
 import potenday.pilsa.challenge.domain.repository.ChallengeRepository;
 import potenday.pilsa.challenge.dto.request.RequestChallengeList;
+import potenday.pilsa.challenge.dto.request.RequestChallengePilsa;
 import potenday.pilsa.challenge.dto.request.RequestCreateChallenge;
 import potenday.pilsa.challenge.dto.request.RequestModifyChallenge;
 import potenday.pilsa.challenge.dto.response.ResponseChallengeInfo;
 import potenday.pilsa.challenge.dto.response.ResponseChallengeList;
+import potenday.pilsa.challenge.dto.response.ResponseChallengePilsaInfo;
+import potenday.pilsa.challenge.dto.response.ResponseChallengePilsaInfoList;
 import potenday.pilsa.global.exception.BadRequestException;
 import potenday.pilsa.global.exception.ExceptionCode;
 import potenday.pilsa.global.util.LocalDateUtil;
 import potenday.pilsa.member.domain.Member;
 import potenday.pilsa.member.domain.Status;
 import potenday.pilsa.member.domain.repository.MemberRepository;
+import potenday.pilsa.pilsa.domain.Pilsa;
 import potenday.pilsa.pilsa.domain.repository.PilsaRepository;
 import potenday.pilsa.pilsaCategory.domain.PilsaCategory;
 import potenday.pilsa.pilsaCategory.domain.YN;
@@ -109,6 +113,24 @@ public class ChallengeService {
 
         challenges.forEach(Challenge::setStatus);
     }
+
+    public ResponseChallengePilsaInfoList getChallengePilsa(Long memberId, RequestChallengePilsa requestChallengePilsa) {
+        List<Pilsa> pilsas;
+
+        if (requestChallengePilsa.getLocalDate() != null) {
+            LocalDateTime startDt = LocalDateUtil.startLocalDateToTime(requestChallengePilsa.getLocalDate());
+            LocalDateTime endDt = LocalDateUtil.endLocalDateToTime(requestChallengePilsa.getLocalDate());
+
+            pilsas = pilsaRepository.findByMember_IdAndChallenge_IdAndDeleteDateIsNullAndRegistDateBetweenOrderByRegistDateDesc(
+                    memberId, requestChallengePilsa.getChallengeId(), startDt, endDt);
+        } else {
+            pilsas = pilsaRepository.findByMember_IdAndChallenge_IdAndDeleteDateIsNullOrderByRegistDateDesc(
+                    memberId, requestChallengePilsa.getChallengeId());
+        }
+
+        return ResponseChallengePilsaInfoList.from(pilsas);
+    }
+
 
     private Member getMember(Long memberId) {
         return memberRepository.findByIdAndStatus(memberId, Status.ACTIVE).orElseThrow(() -> new BadRequestException(ExceptionCode.NOT_FOUND_MEMBER));

--- a/src/main/java/potenday/pilsa/pilsa/domain/repository/PilsaRepository.java
+++ b/src/main/java/potenday/pilsa/pilsa/domain/repository/PilsaRepository.java
@@ -30,4 +30,8 @@ public interface PilsaRepository extends JpaRepository<Pilsa, Long>, PilsaQRepos
     List<Pilsa> findByMember_IdAndRegistDateBetweenAndDeleteDateIsNull(Long member_id, LocalDateTime registDate, LocalDateTime registDate2);
     List<Pilsa> findByMember_IdAndChallenge_IdAndDeleteDateIsNull(Long member_id, Long challenge_id);
 
+    List<Pilsa> findByMember_IdAndChallenge_IdAndDeleteDateIsNullAndRegistDateBetweenOrderByRegistDateDesc(Long member_id, Long challenge_id, LocalDateTime registDate, LocalDateTime registDate2);
+    List<Pilsa> findByMember_IdAndChallenge_IdAndDeleteDateIsNullOrderByRegistDateDesc(Long member_id, Long challenge_id);
+
+
 }


### PR DESCRIPTION
## 🔥 관련 이슈
Issue: #101 

## ✨ 변경사항
- 챌린지 번호와 날짜를 통해서 필사 리스트를 조회합니다.
- 챌린지 번호만을 이용해서 필라 리스트를 조회할 수 있습니다.
- 날짜가 포함된다면 해당 날짜에 등록한 필사리스트를 가져올 수 있습니다.
- Request, ResponseDto 가 추가되었습니다.
- 관련 기능 API 와 서비스 로직이 추가되었습니다.

## 📝 작업 유형
- [x] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 업데이트
- [ ] 단순 코드 스타일 변경 (세미콜론 추가 등)
- [ ] 배포 관련

## ✅ 체크리스트
- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] 해당 PR과 관련없는 변경사항이 없는가? (만약 있다면 제목이나 변경사항에 기술하여 주세요.)
- [x] 실행시 console 창에 에러나 경고가 없는것을 확인하였는가?
